### PR TITLE
Remove computed field API-Key example text

### DIFF
--- a/docs/_docs/advanced.md
+++ b/docs/_docs/advanced.md
@@ -56,8 +56,6 @@ Computed Fields, on the other hand, store values obtained from an integration's 
 
 {% raw %}`{{bundle.authData.field}}`{% endraw %}
 
-Say your app includes a subdomain that can be fetched with an API call using the API key—and your other API calls require the subdomain be used in requests. You would add a computed field that references that value from your server's response, much like the way you reference fields in connected accounts.
-
 Zapier stores all fields returned by authentication API test call and auth process. Computed fields are marked as _required_ so Zapier watches specifically for those fields in the response data. If the auth process does not return fields marked as computed fields, Zapier will show an error. For example, if using OAuth v.2 authentication, Zapier will store all fields returned by the `getAccessToken` request, and will show an error if the response doesn't include an access token along with any fields you marked as computed fields.
 
 ### How to Use a Field From the Test API Call as a Computed Field?

--- a/docs/_docs/advanced.md
+++ b/docs/_docs/advanced.md
@@ -56,7 +56,7 @@ Computed Fields, on the other hand, store values obtained from an integration's 
 
 {% raw %}`{{bundle.authData.field}}`{% endraw %}
 
-Zapier stores all fields returned by authentication API test call and auth process. Computed fields are marked as _required_ so Zapier watches specifically for those fields in the response data. If the auth process does not return fields marked as computed fields, Zapier will show an error. For example, if using OAuth v.2 authentication, Zapier will store all fields returned by the `getAccessToken` request, and will show an error if the response doesn't include an access token along with any fields you marked as computed fields.
+Zapier stores all fields returned by authentication API test call and auth process. Computed fields are marked as _required_ so Zapier watches specifically for those fields in the response data. If the auth process does not return fields marked as computed fields, Zapier will show an error. For example, if using OAuth v.2 authentication, Zapier will store all fields returned by the `getAccessToken` request, and will show an error if the response doesn't include an access token along with any fields you marked as computed fields. You could use a computed field, then, to reference a field that the `getAccessToken` call returns if you need to use it in subsequent API calls.
 
 ### How to Use a Field From the Test API Call as a Computed Field?
 


### PR DESCRIPTION
We have a note that says you should only use computed fields with session or OAuth v2. But then just below that we reference an API key in the example.
![](https://zappy.zapier.com/0997F290-2076-4429-BB0D-8A52F436EBE1.png)  

This has caused some confusion for developers trying to include computed fields with Visual Builder apps using API Key auths.