### PR TITLE
add split file

### DIFF
--- a/docs/_cli_docs/split.md
+++ b/docs/_cli_docs/split.md
@@ -1,0 +1,82 @@
+---
+title: Examples In Each
+order: 3
+layout: post-toc
+redirect_from: /split/
+---
+
+<script>
+  const storageKey = 'zapier.appType';
+  const godzilla = 'godzilla';
+  const cli = 'cli';
+
+  const _iterate = (klass, display) => {
+    for (const el of document.querySelectorAll(`.${klass}`)) {
+      el.style.display = display;
+    }
+  };
+
+  const showAll = klass => {
+    _iterate(klass, 'block');
+  };
+  const hideAll = klass => {
+    _iterate(klass, 'none');
+  };
+
+  const showCli = () => {
+    window.localStorage.setItem(storageKey, cli);
+    showAll(cli);
+    hideAll(godzilla);
+  };
+
+  const showGodzilla = () => {
+    window.localStorage.setItem(storageKey, godzilla);
+    showAll(godzilla);
+    hideAll(cli);
+  };
+
+  window.onload = () => {
+    const appType = window.localStorage.getItem(storageKey) || cli; // default to CLI
+
+    if (appType === cli) {
+      showCli();
+    } else {
+      showGodzilla();
+    }
+  };
+</script>
+
+# Examples in Each
+
+Here's how you do some things in both CLI and Godzilla
+
+<a class="button blue" href="#" onclick="showCli()">CLI</a>
+<a class="button blue" href="#" onclick="showGodzilla()">Godzilla</a>
+
+## Lifecycle
+
+The basic flow in which you do things
+
+### Promotion
+
+When it's time for an app to be seen by users, you need to do this:
+
+<div class="cli">
+  <div class="highlighter-rouge">
+    <div class="highlight">
+      <pre class="highlight"><code>$ zapier promote 1.2.3
+</code></pre>
+    </div>
+  </div>
+</div>
+
+<div class="godzilla">
+  <p>
+    <img
+      src="https://zappy.zapier.com/F7646205-9EEE-4892-B520-A8EAD616FFB1.png"
+      alt=""
+    />
+  </p>
+</div>
+
+That's how you do it!


### PR DESCRIPTION
Super basic proof of concept about how we might have simultaneous docs for CLI and godzilla.

Major downsides are:

* the content in both `div`s is flashed on page load, before the hiding happens
* the content in each div isn't markdown, it needs to be html. 

Upside, the browser remembers which app type a user looked at and it'll persist between tabs and sessions. 

I think we wouldn't go all the way with this, but it could be an option. Could also maybe do something like [slate](https://lord.github.io/slate/?shell#introduction) ([source for that page](https://raw.githubusercontent.com/lord/slate/master/source/index.html.md)), which turns markdown into different code examples. 

Not sure that would jive well with godzilla though, which would be mostly images (rather than CLI, which is code). 

Switching gears, we could so something more custom (like [Gatsby](https://www.gatsbyjs.org/)), which could pull in markdown and let us do custom CLI/godzilla components. 