### PR TITLE
Update Logo Specs to include maximum size

### DIFF
--- a/docs/_docs/start.md
+++ b/docs/_docs/start.md
@@ -11,7 +11,7 @@ redirect_from: /docs/
 
 Every new Zapier integration starts with details about the app. Zapier integrates with 1,300+ apps, and counting. That makes it crucial to help people find your app among all the others on the platform. With a clear description and logo, and placement in the category that best represents your app, your users will be able to easily find your app and new users will likely discover your app as they search for tools that fit their needs.
 
-To make a new integreation in Zapier Platform UI:
+To make a new integration in Zapier Platform UI:
 
 1. Open Zapier's visual builder at [zapier.com/app/developer](https://zapier.com/app/developer/)
 2. Fill in the details about your app

--- a/docs/_docs/start.md
+++ b/docs/_docs/start.md
@@ -36,7 +36,7 @@ Use proper English, complete sentences, and punctuation. Do not include links or
 <a id="logo"></a>
 ## Logo
 
-Upload your app's logo. Make sure your logo is a square, transparent PNG file with dimensions of at least 256x256px (use a larger image if available). If your logo uses a solid background, round the corners 3% of the width and make their background transparent.
+Upload your app's logo. Make sure your logo is a square, transparent PNG file with dimensions of at least 256x256px (use a larger image if available, but do not exceed 2048x2048px). If your logo uses a solid background, round the corners 3% of the width and make their background transparent.
 
 Do not include your app's name in the logomark, as it will not be legible at smaller sizes.
 


### PR DESCRIPTION
Zapier doesn't accept logo image files that are larger than 2048x2048 pixels. 
This fails silently (says successful but the logo doesn't upload) when trying to upload the image in the developer portal.

Adding the maximum size restriction to the logo spec. 