### PR TITLE
Remove reference to File type for input-designer

### DIFF
--- a/docs/_docs/input-designer.md
+++ b/docs/_docs/input-designer.md
@@ -229,12 +229,6 @@ DateTime fields let users enter dates and times, using their human readable valu
 
 > Learn more about how users can [modify dates and times in Zapier][2]{:target="_blank"}.
 
-### File
-
-![Zapier File Field][image-14]
-
-File fields let users select a file object from a previous Zap step or enter a public URL to a file, where Zapier will then send the file to your API.
-
 ### Password
 
 ![Zapier Password Field][image-15]


### PR DESCRIPTION
https://github.com/zapier/zapier/issues/28474

We don't support File type for inputs in the Platform visual-builder. This removes reference to File type from docs.