### PR TITLE
Add redirect from /partners/app-review-guidelines/ to integration review guidelines doc

### DIFF
--- a/docs/_partners/integration-review-guidelines.md
+++ b/docs/_partners/integration-review-guidelines.md
@@ -2,7 +2,8 @@
 title: Zapier Integration Review Guidelines
 order: 9
 layout: post-toc
-redirect_from: /partners/
+redirect_from: /partners/app-review-guidelines
+---
 
 # Zapier Integration Review Guidelines
 


### PR DESCRIPTION
Reverting the last commit as it seems I didn't wait long enough for the first deploy and that was the accurate fix.