### PR TITLE
Remove funky encoding from 'promote' section

### DIFF
--- a/docs/_cli_docs/cli.md
+++ b/docs/_cli_docs/cli.md
@@ -622,13 +622,13 @@ Note: since a migration is only for non-breaking changes, users are not emailed 
 
 Promotes an app version into production (non-private) rotation, which means new users can use this app version.
 
-* This [1mdoes[22m mark the version as the official public version - all other versions & users are grandfathered.
+* This does mark the version as the official public version - all other versions & users are grandfathered.
 
-* This does [1mNOT[22m build/upload or deploy a version to Zapier - you should `zapier push` first.
+* This does NOT build/upload or deploy a version to Zapier - you should `zapier push` first.
 
-* This does [1mNOT[22m move old users over to this version - `zapier migrate 1.0.0 1.0.1` does that.
+* This does NOT move old users over to this version - `zapier migrate 1.0.0 1.0.1` does that.
 
-* This does [1mNOT[22m recommend old users stop using this version - `zapier deprecate 1.0.0 2017-01-01` does that.
+* This does NOT recommend old users to stop using this version - `zapier deprecate 1.0.0 2017-01-01` does that.
 
 Promotes are an inherently safe operation for all existing users of your app.
 


### PR DESCRIPTION
Fixing some funky encoding or extra text from the `zapier promote` section of our platform docs
![screenshot](https://s3.amazonaws.com/zapier-cloudapp/items/wbumlmJw/Image%202020-04-01%20at%2011.19.33%20AM.png).

Confirmed it doesn't appear this way in the original CLI docs - https://zapier.github.io/zapier-platform/cli#promote

