### PR TITLE
Taylorhalliday/fix code in tutorial

### DIFF
--- a/docs/_cli_tutorials/resthooks.md
+++ b/docs/_cli_tutorials/resthooks.md
@@ -52,7 +52,8 @@ const subscribeHook = (z, bundle) => {
 
   // make the request and parse the response - this does not include any error handling.
   return z.request(options)
-    .then((response => z.JSON.parse(response.content));
+    .then(response => z.JSON.parse(response.content));
+}
 ```
 
 which is then called in the `performSubscribe` method on the module for the Trigger, like so:

--- a/docs/_cli_tutorials/resthooks.md
+++ b/docs/_cli_tutorials/resthooks.md
@@ -82,11 +82,11 @@ const unsubscribeHook = (z, bundle) => {
 
   const options = {
     url: `your endpoint url/${hookId}`,
-    method: 'DELETE',
+    method: 'DELETE'
   }
 
   return z.request(options)
-    .then((response => z.JSON.parse(response.content));
+    .then(response => z.JSON.parse(response.content));
 };
 ```
 
@@ -146,7 +146,7 @@ const getFallbackSample = (z, bundle) => {
   };
 
   return z.request(options)
-    .then((response) => JSON.parse(response.content));
+    .then(response => JSON.parse(response.content));
 };
 ```
 


### PR DESCRIPTION
- Minor code syntax cleanup w missing parens on the arrow syntax
- Removed a trailing comma for consistency in the doc