### PR TITLE
[SUPPORTESC-101] Change 90-day limit for callbacks to 30-day

### DIFF
--- a/docs/_cli_docs/docs.md
+++ b/docs/_cli_docs/docs.md
@@ -1572,7 +1572,7 @@ const performResume = async (z, bundle) => {
 };
 ```
 
-> The app will have a maximum of 90 days to `POST` to the callback URL. If a user deletes or modifies the Zap or Task in the meantime, we will not resume the task.
+> The app will have a maximum of 30 days to `POST` to the callback URL. If a user deletes or modifies the Zap or Task in the meantime, we will not resume the task.
 
 
 ## Bundle Object


### PR DESCRIPTION
We believe that due to tasks no longer being saved for 90 days, a callback posting after 30 days has a risk of failing, so the documentation should state 30 days as the max.