### PR TITLE
PDE-1820: Example CLI apps anchor link is dead

### DIFF
--- a/docs/_cli_docs/docs.md
+++ b/docs/_cli_docs/docs.md
@@ -102,7 +102,7 @@ cd example-app
 npm install
 ```
 
-> Note: there are plenty of templates & example apps to choose from! [View all Example Apps here.](#example-apps).
+> Note: there are plenty of templates & example apps to choose from! [View all Example Apps here.](https://github.com/zapier/zapier-platform/tree/master/example-apps).
 
 You should now have a working local app. You can run several local commands to try it out.
 

--- a/docs/_cli_docs/docs.md
+++ b/docs/_cli_docs/docs.md
@@ -102,7 +102,7 @@ cd example-app
 npm install
 ```
 
-> Note: there are plenty of templates & example apps to choose from! [View all Example Apps here.](https://github.com/zapier/zapier-platform/tree/master/example-apps).
+> Note: there are plenty of templates & example apps to choose from! [View all Example Apps here.](https://github.com/zapier/zapier-platform/tree/master/example-apps)
 
 You should now have a working local app. You can run several local commands to try it out.
 


### PR DESCRIPTION
I'm not sure where this used to go - was it this page, or did we render that page as an anchor somewhere?