### PR TITLE
[SUPPORTESC-106] Reorganize sample data / output fields info, add three-sample limit

### DIFF
--- a/docs/_docs/actions.md
+++ b/docs/_docs/actions.md
@@ -82,24 +82,24 @@ If your app returns an error, be sure to check:
 - Input Field Keys: Did you use the same field keys in your input field as your API expects? Double-check that in the Input Designer, and change if needed.
 - API Call Customization: Does your API expect something different than the standard API call details Zapier sets by default? You may need to use custom coding if the options you need aren't available.
 
+### Define Sample Data and Output Fields
+
 ![Zapier Define Output Fields](https://cdn.zapier.com/storage/photos/ae070045d9e23b162f1b0a0a1507b029.png)
 
-Every time your action step runs, your API will return data to Zapier—ideally detailing the item that was added to your app or found via a search. Each item includes multiple details, including each item users would add via the Zap input form along with extra details, often with items users may not care about as much.
+Every time your action step runs, your API will return data to Zapier—ideally detailing the item that was added to your app or found via a search. Each item includes multiple details, including any attribute users would add via the Zap input form, along with other attributes or details that users may not care about as much.
 
 Zapier lets you define the most important fields with friendly field names. Each field you define will show up first in the output field list after the Zap runs, and will be usable in subsequent Zap steps.
 
-In the _Sample_ box, add a JSON formatted example of the output data from your API with the most commonly used output fields. Include the field key on the left, and sample data for that field on the right, using sample, demo data that can be used publicly.
+First, fill in sample data by clicking the _Use Response from Test Data_ button to import the fields your app sent to Zapier in the previous test, or add your own JSON-formatted fields. This data will also be used as a fallback in the Zap Editor if users skip the test step for the action, so that these fields can still be mapped into other steps. Make sure the data you include with those fields is non-private, non-identifiable testing data that can be shared publicly.
 
-Then click _Generate Output Field Definitions_ and Zapier will list a table of the fields with the keys on the left and the field type on the right. Select the correct field type (including the default String field or Text, integer, number, boolean, datetime, file, and password field options), and add a human-friendly field name in the center column.
-
-_[Learn more about how Zapier uses sample data and output fields](http://zapier.github.io/visual-builder/docs/faq#output)_.
+Then click _Generate Output Field Definitions_ and Zapier will list a table of the fields with the keys on the left and the field type on the right. Add a human-friendly name for each field in the center column, especially if users might expect a different name than the API provides, as in the GitHub example above where `body` becomes "Issue Details".  Then select the field type. Lastly, click _Save Output & Finish_ to complete your action.
 
 <a id="code"></a>
 ## How to Use Custom Code in Zapier Actions
 
 ![Zapier visual builder code mode](https://cdn.zapier.com/storage/photos/0e52a1110b0f6cd37afd4c005e97dfa0.png)
 
-The default API settings form is the best option for most actions with default settings. If your action needs customized API calls, scripting to manipulate input field data, or other unique features, you can add custom JavaScript code for your API request.
+The default API settings form is the best option for most actions. If your action needs customized API calls, scripting to manipulate input field data, or other unique features, you can add custom JavaScript code for your API request.
 
 To use custom code, click the _Switch to Code Mode_ button. Zapier will translate your default API call settings into JavaScript code the first time you switch to code mode for an easy way to start. If you switch back to form mode, though, Zapier will not transfer your code settings back to the form.
 

--- a/docs/_docs/faq.md
+++ b/docs/_docs/faq.md
@@ -192,7 +192,7 @@ Output Fields add user-friendly labels to your API's response data. Zapier uses 
 
 For example, if you use GitHub's API to watch for new issues, the API calls the issue name `title`. Users may expect that field to be called _Issue_ or _Issue Title_, so you could define the Output Field as having the name _Issue Title_, rather than the default transformation of "Title".
 
-You can learn more about how Zapier uses sample data and output fields in [triggers]() and [actions]().
+You can learn more about how Zapier uses sample data and output fields in [triggers](/docs/triggers#define-sample-data-and-output-fields) and [actions](/docs/actions#define-sample-data-and-output-fields).
 
 <a id="resthooktesting"></a>
 ## How do I define Rest Hooks and use the embedded tester with them?

--- a/docs/_docs/faq.md
+++ b/docs/_docs/faq.md
@@ -8,7 +8,7 @@ redirect_from: /docs/
 # Frequently Asked Questions
 
 <a id="save"></a>
-## Does Zapier Auto-Save Integrations?
+## Does Zapier auto-save integrations?
 
 _No_. Always remember to save your work when building integrations. Zapier asks you to save and continue in several spots while building integrations, so be sure to save at each point:
 
@@ -25,7 +25,7 @@ When adding a new trigger or action, there is a _Save_ button after the Zap step
 When adding a new field to an authentication, trigger, or action step's input field, click _Save_ after adding the field details.
 
 <a id="code"></a>
-## How Does Code Mode Work?
+## How does Code Mode work?
 
 ![Zapier visual builder code mode](https://cdn.zapier.com/storage/photos/5abf045cf0b8f3cce37d05d51071d6e9.png)
 _Each API call pane in Zapier visual builder includes a code mode toggle_
@@ -61,14 +61,14 @@ If you wish to switch back to the form mode, click the _Switch to Form Mode_ but
 
 You may switch back to code mode again—though this time, Zapier will show the last saved version of your code, and will not copy any changes from your API call form to the code.
 
-## Is my Zapier Integration Using the Form or Code Mode Settings?
+## Is my Zapier integration using the Form or Code Mode settings?
 
 Zapier uses the currently visible option when running each part of your integration. If the form mode is visible for an API call in an integration's authentication, trigger, or action settings, that Zapier integration is using the data from form mode. If the code mode is visible for an API call, Zapier is using the code instead to turn that part of the integration.
 
 To check which mode and settings Zapier is using for each API call, open that part of your Zapier integration and visually check to see if the form or code mode is visible.
 
 <a id="cli"></a>
-## Why Are Options Grayed Out For my CLI-built Integration?
+## Why are options grayed out for my CLI-built integration?
 
 ![Zapier CLI integration in visual builder](https://cdn.zapier.com/storage/photos/c631ca2cd91ab43b0bc4d22f641eb4d6.png)
 
@@ -97,7 +97,7 @@ No. If you'd like to work with file attachments in your app, you'll need to conv
 
 <a id="files"></a>
 
-## What Response Type Does Zapier Expect?
+## What response type does Zapier expect?
 
 With every API call, including authentication and auth testing calls, triggers, searches, and create actions, Zapier expects to receive response data from the API. If your API call does not return a response, Zapier will show a timeout error.
 
@@ -107,7 +107,7 @@ Zapier additionally expects different data for different API calls:
 - **Array** *for Triggers and Search Actions*. Zapier expects to receive a JSON formatted array with the results in reverse chronological order. Even if the trigger or search only returns a single item, it should be formatted as an array. Zapier will then parse the results and return the most relevant result for searches, and return all new items from Triggers that pass Zapier's deduper.
 
 <a id="array"></a>
-## I Got an "An array is Expected" error. How do I Fix That?
+## I got an "An array is expected" error. How do I fix that?
 
 With you add a polling trigger or search action to a Zap, the Zapier platform expects to get a bare array of the new or found items, sorted in reverse chronological order. APIs will instead return a result _object_ that contains the array of items the trigger needs.
 
@@ -149,7 +149,7 @@ Now, retest the request and it should run successfully. Note the response this t
 ![](https://cdn.zapier.com/storage/photos/33098c9f9c1584295e074c1dc8a40e72.png)
 
 <a id="censored"></a>
-## Why Does Zapier Show `censored` Fields in Request and Response Data?
+## Why does Zapier show `censored` fields in request and response data?
 
 ![Example censored fields in Zapier](https://cdn.zapier.com/storage/photos/9356f3af9c0a844a652868d877e22486.png)
 
@@ -158,7 +158,7 @@ When testing Authentication, Triggers, or Actions in Zapier visual builder, you 
 Zapier automatically censors sensitive values at runtime, including all input fields marked as `password` and all authentication fields that will include sensitive, private data including username and password fields from Basic and Digest auth, API keys from API key auth, access and refresh tokens from Session and OAuth v2 authentication. These values are stored in the `Auth` bundle and used in API calls, but are replaced in Zapier's logs with a `censored` value.
 
 <a id="cleanup"></a>
-## How to Clean Up Test Authentication Accounts?
+## How do I clean up test authentication accounts?
 
 ![Example account with multiple test accounts](https://cdn.zapier.com/storage/photos/7fe9f9155dafbcc5d9b461720d664d4d.png)
 
@@ -166,46 +166,36 @@ While building your integration, testing authentication, and customizing your ap
 
 ![Remove authed accounts](https://cdn.zapier.com/storage/photos/c7fe45e90f7c4c00f6ffd938d417cdd0.png)
 
-Open your [Zapier _Connected Accounts_](https://zapier.com/app/settings/authorizations) page, and press `CMD`+`F` or `Ctrl`+`F` then search for your app's name. Click _Disconnect_ then confirm to remove any account, and repeat for each subsequent testing account you added to clean up your authentication list.
+Open your [Zapier _Connected Accounts_](https://zapier.com/app/connections) page, and find your app's name (you may need to use the search box or `CMD`+`F` (Mac) or `Ctrl`+`F` (PC)). Click the app name. Once on the app's connections page, identify the connection to remove and click the three dots, then _Delete_, and confirm the deletion. Repeat for each subsequent testing account you added to clean up your authentication list.
 
-Then refresh your integration page in visual builder, and you'll only see the authentications you left running.
+Then refresh your integration page in the Visual Builder, and you'll only see the authentications that were not deleted.
 
 <a id="output"></a>
-## How do Sample Data and Output Fields Work?
+## How do Sample Data and Output Fields work?
 
 ![Adding Sample Data to Zapier integration](https://cdn.zapier.com/storage/photos/8ab32f061aa89f3b57e8f4a5ea16a9d9.png)
-_Sample Data gives Zapier example data if users don't test the trigger or action; Output Fields give your API data user-friendly names in subsequent Zap steps_
+_Sample Data gives Zapier example data if users don't test the trigger or action. Output Fields give your API data user-friendly names in subsequent Zap steps._
 
-The last step in creating a new Trigger or Action for a Zapier integration is to _Define your Output_. Here, Zapier asks both for Sample Data and Output Fields. Neither are required, but both help improve the Zapier experience for your users.
+The last step in creating a new Trigger or Action for a Zapier integration is to _Define your Output_. Zapier asks both for Sample Data and Output Fields. Sample Data is especially important for Triggers, and useful with Actions as well. Output Fields are equally important for both triggers and actions, as the output data from both may be used in subsequent Zap steps.
+
+### Sample Data
 
 ![Sample Data in a Zap Step](https://cdn.zapier.com/storage/photos/d4e5d47c461efa897a907c2806aecc1d.png)
 
-Sample Data lists the default data Zapier shows users when building a Zap using this step. By default, Zapier will ask to test the Zap step after users set it up. With Triggers, Zapier will try to fetch recently added or updated items; with Actions, Zapier will try to find or create the item using the user's data.
+In the Zap Editor, Zapier will attempt to retrieve or create existing data to test Triggers and Actions. If users are in a hurry when building a Zap, or don't have any data available, they can skip these test steps. Zapier will then show the sample data instead, so they can map fields correctly in subsequent Zap steps without seeing their account's live data.
 
-If users are in a hurry, though, they can click _Skip This Step_. Zapier will then show the sample data instead, both with triggers and actions, so they can map fields correctly in subsequent Zap steps without seeing their app account's live data. Or with triggers, if your app doesn't have any data for this item yet, Zapier will default to showing the sample data instead of showing an error that no items are available.
+Make sure to provide JSON-formatted sample data using the same field names as your API. The sample response data should not include any personally identifiable data, have copy that is safe for work, and be easily recognizable as sample data.
 
-Sample Data is especially important for Triggers, and useful with Actions as well.
+### Output Fields
 
-To include sample data in your integration, open the final step of your Zapier trigger or action's API Configuration. There, write valid JSON output data using the same field names as your API with sample response data that does not include any personally identifiable data, is safe for work copy, and is easily recognizable as sample data. Here are example sample data for a GitHub issue:
+Output Fields add user-friendly labels to your API's response data. Zapier uses a basic human-friendly transformation of field names by default, capitalizing words and adding spaces instead of underscores. You can customize this further with Output Fields.
 
-    {
-      "body": "This is a sample issue",
-      "html_url": "https://github.com/",
-      "title": "Test Issue"
-    }
+For example, if you use GitHub's API to watch for new issues, the API calls the issue name `title`. Users may expect that field to be called _Issue_ or _Issue Title_, so you could define the Output Field as having the name _Issue Title_, rather than the default transformation of "Title".
 
-![Adding Output Fields to Zapier integration](https://cdn.zapier.com/storage/photos/31d6247a888135ed334d5035ce4b0ade.png)
-
-Output Fields add user-friendly labels to your API's response data. By default, Zapier will try to make friendly version of your API's response, capitalizing words and adding spaces instead of underscores. You can customize this further with Output Fields.
-
-For example, if you use GitHub's API to watch for new issues, the API calls the issue name _Title_. Users may expect that field to be called _Issue_ or _Issue Title_, so you could define that add a custom name for that field.
-
-Output Fields are equally important for both triggers and actions, as the output data from both may be used in subsequent Zap steps.
-
-To add output fields, list the original field name from your API response in the left column, and a human friendly name for the field in the right column of your Zapier trigger or action's API configuration. Zapier will then substitute those names for those output field titles in your users' Zaps as in the screenshot above.
+You can learn more about how Zapier uses sample data and output fields in [triggers]() and [actions]().
 
 <a id="resthooktesting"></a>
-## How Do I Define Rest Hooks and Use the Embedded Tester With Them?
+## How do I define Rest Hooks and use the embedded tester with them?
 
 Rest Hooks are a great way to implement Zapier Triggers.  They allow you to _push_ new data as soon as it's available in your product.  You'll also only connect when there _is_ new data, and avoid polling altogether.
 

--- a/docs/_docs/triggers.md
+++ b/docs/_docs/triggers.md
@@ -108,13 +108,24 @@ Click _Test Your Result_, and if your trigger is set up correctly, you'll see a 
 
 Zapier will show the raw, JSON formatted response from your API in the _Response_ tab with every output field your app sends to Zapier. You can see the data Zapier sent to your API in the _Bundle_ tab, or the raw HTTP request in the _HTTP_ tab.
 
-![Zapier Define Output Fields](https://cdn.zapier.com/storage/photos/d9a84ecb06a3f8f9e40fb91ba1a63ea5.png)
+### Define Sample Data and Output Fields
 
-As a final step, you need to define the most important output fields to help users easily know what data from your app they should use in subsequent Zap steps. In the _Sample Data_ box, either click the _Use Response from Test Data_ button to import the fields your app sent to Zapier in the previous test, or add your own JSON-formatted fields. Only keep the most important fields, and make sure the data you include with those fields is non-private, non-identifiable testing data that can be shared publicly.
+![Adding Sample Data to Zapier integration](https://cdn.zapier.com/storage/photos/8ab32f061aa89f3b57e8f4a5ea16a9d9.png)
+_Sample Data gives Zapier example data if users don't test the trigger or action. Output Fields give your API data user-friendly names in subsequent Zap steps._
 
-Then click _Generate Output Field Definitions_, and Zapier will build a table of your fields under _Output Fields_. Add a human friendly name for each field and select the field type. Click _Save Output & Finish_ to finish the final part of your trigger.
+The last step in creating a new Trigger for a Zapier integration is to _Define your Output_. Here, Zapier asks both for Sample Data and Output Fields. Both will help improve the Zapier experience for your users, and Sample Data is especially important for Triggers.
 
-_[Learn more about how Zapier uses sample data and output fields](http://zapier.github.io/visual-builder/docs/faq#output)_.
+![Sample Data in a Zap Step](https://cdn.zapier.com/storage/photos/d4e5d47c461efa897a907c2806aecc1d.png)
+
+Sample Data is the default data Zapier shows users when building a Zap using this trigger. In the Zap Editor, Zapier will ask to test the Zap step after users set it up. With Triggers, Zapier will try to fetch recently added or updated items during the test.
+
+If users are in a hurry, though, they can skip the testing step. Zapier will then show the sample data instead. Or, if the connected account doesn't have any data for this item yet, Zapier will default to showing the sample data instead of showing an error that no items are available.
+
+Note that regardless of how many items are retrieved when testing, the Zap Editor will only show up to three samples during the initial test. If new items are later added, those can be pulled in using "Load More", but older items will not be used.
+
+In the _Sample Data_ box, either click the _Use Response from Test Data_ button to import the fields your app sent to Zapier in the previous test, or add your own JSON-formatted fields. Only keep the most important fields, and make sure the data you include with those fields is non-private, non-identifiable testing data that can be shared publicly.
+
+Then click _Generate Output Field Definitions_, and Zapier will build a table of your fields under _Output Fields_. Add a user-friendly name for each field and select the field type. Click _Save Output & Finish_ to finish the final part of your trigger.
 
 You can now make a new Zap using your trigger to test out the trigger live inside Zapier.
 


### PR DESCRIPTION
This PR does a few things. Its main focus is to:

* Reorganize the information about sample data and output fields, moving more of it to the Triggers and Actions pages rather than the FAQ, and making it more specific to each use (as well as trying to make some of the common content more consistent). 
* Change the FAQ to refer to these pages instead of these pages referring to the FAQ.

[Slack context](https://zapier.slack.com/archives/C5Z9BP4U9/p1609787059096700). This did result in additional information duplication, which isn't ideal. I met with @megan-driscoll to talk about this & other IA concerns, so we can ideally improve on this in the future.

I also did some cleanup:

* Updated the process for deleting connections to reflect the new My Apps page
* Changed FAQ titles to sentence case to conform with the [style guide](https://brand.zapier.com/content/grammar-and-mechanics.html#capitalization).