### PR TITLE
[SUPPORTESC-124] Add note in lifecycle planning that auth is required for public integrations

### DIFF
--- a/docs/_partners/lifecycle-planning.md
+++ b/docs/_partners/lifecycle-planning.md
@@ -49,7 +49,7 @@ Learn how to use the Zapier Platform with our [visual builder Quick Start tutori
 
 ### Test Your Integration
 
-While you're building your integration, it's best to test authentication, triggers, and actions as you add them to your app. In Platform UI, you can test each step live in the editor as its built. With both Platform UI and CLI, have a separate tab open in your browser to the user-facing [Zap editor](https://zapier.com/app/editor), then refresh anytime you add a new trigger or action to test it live immediately.
+While you're building your integration, it's best to test authentication, triggers, and actions as you add them to your app. In Platform UI, you can test each step live in the editor as it's built. With both Platform UI and CLI, have a separate tab open in your browser to the user-facing [Zap editor](https://zapier.com/app/editor), then refresh anytime you add a new trigger or action to test it live immediately.
 
 > **Note:** You may have to refresh a few times for new triggers and actions to appear.
 

--- a/docs/_partners/planning-guide.md
+++ b/docs/_partners/planning-guide.md
@@ -129,7 +129,9 @@ With OAuth v2, when users select to connect their account on your app with Zapie
 
 The second best option is API Key authentication. Users should be able to obtain their API key from your app without human intervention. Zapier will not allow your integration to be publicly released if your service requires users to email or call your team in order to receive an API Key or access to your API.
 
-Basic authentication, while acceptable, is the least appropriate authentication type to use for a third party service like Zapier, as users must type their account credentials directly into Zapier's UI.
+Basic authentication, while acceptable, is the least appropriate authentication type to use for a third-party service like Zapier, since users must enter their account credentials directly into Zapier's UI.
+
+For security and consistency across the platform, any integration intended for public release on Zapier must use authentication.
 
 Here are additional considerations when adding authentication to your integration:
 


### PR DESCRIPTION
This was noted internally, but didn't seem to be highlighted externally, and will help with integration planning.