### PR TITLE
remove empty "Updates" section

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -25,9 +25,6 @@ collections:
   docs:
     output: true
     permalink: /:collection/:name
-  news:
-    output: true
-    permalink: /:collection/:name
   cli_docs:
     output: true
     permalink: /:collection/:name


### PR DESCRIPTION
All of these posts were removed in https://github.com/zapier/visual-builder/pull/169, but the section header was left out. 

