### PR TITLE
[SUPPORTESC-139] Note that Promote isn't used for private apps, clean up versions page

### DIFF
--- a/docs/_docs/testing.md
+++ b/docs/_docs/testing.md
@@ -7,9 +7,9 @@ redirect_from: /docs/
 
 ## Test Your Integration
 
-Zapier includes a number of ways to test your integration before releasing it to users, both inside Zapier's visual builder with tools to test each part of your integration, as well as the Zap builder itself.
+Zapier includes a number of ways to test your integration before releasing it to users, both inside Zapier's Platform UI with tools to test each part of your integration, as well as the Zap editor itself.
 
-Zapier visual builder helps you test your integration's authentication, triggers, and actions while building your integration. Then, be sure to test your integration in Zaps yourself, and invite others to help test your integration as well.
+The Platform UI helps you test your integration's authentication, triggers, and actions while building your integration. Then, be sure to test your integration in Zaps yourself, and invite others to help test your integration as well.
 
 ## How to Test Authentication
 
@@ -43,9 +43,9 @@ Then click _Test Your Request_ to run the trigger or action step. Zapier will no
 
 ![Test new integration inside Zapier](https://cdn.zapier.com/storage/photos/c288a4e327ca0506da1a93e56c580e6d.png)
 
-Testing inside the visual builder is crucial to building functioning integrations. But to ensure people can easily use your integration, it's equally crucial to test your integration inside Zapier with live Zaps.
+Testing inside the Platform UI is crucial to building functioning integrations. But to ensure people can easily use your integration, it's equally crucial to test your integration inside Zapier with live Zaps.
 
-To test your integration, make a Zap in the [Zap editor](https://zapier.com/app/editor/), and choose your app in the _Choose App_ selector. Your integration will show the name and logo set in visual builder, along with the integration's current version number and a _By invite_ tag. If your integration is a new version of an existing integration, look for the latest version number and the _By invite_ tag to differentiate from existing, public integrations.
+To test your integration, make a Zap in the [Zap editor](https://zapier.com/app/editor/), and choose your app in the _Choose App_ selector. Your integration will show the name and logo set in the Platform UI, along with the integration's current version number and a _By invite_ tag. If your integration is a new version of an existing integration, look for the latest version number and the _By invite_ tag to differentiate from existing, public integrations.
 
 Then be sure to check each of the following:
 
@@ -73,7 +73,7 @@ It's crucial to have as many people test your integration as possible before lau
 
 ![Zapier integration admins](https://cdn.zapier.com/storage/photos/5db3a5364349cbb17812e02e1eeddf11_2.png)
 
-While developing your app integration, invite additional admins from your integration's _Admins_ page. These users will have full access to your app's visual builder to edit the app details, authentication, triggers, actions, and versions. This is the best way to add additional developers to your project.
+While developing your app integration, invite additional admins from your integration's _Admins_ page. These users will have full access to the Platform UI to edit the app details, authentication, triggers, actions, and versions. This is the best way to add additional developers to your project.
 
 ![Zapier integration visibility](https://cdn.zapier.com/storage/photos/c818563358f8566d969e9be09a560220.png)
 
@@ -81,4 +81,4 @@ When your integration is nearly finished and ready for wider testing, you can in
 
 From the [_Monitoring_ page](#monitoring), you'll then see every action taken by your integration users. You can filter by user, see auth and trigger/action events, and see any errors that occur.
 
-The _Analytics_ tab in the visual builder provides usage statistics, focusing on how many users each trigger and action has.
+The _Analytics_ tab in the Platform UI provides usage statistics, focusing on how many users each trigger and action has.

--- a/docs/_docs/testing.md
+++ b/docs/_docs/testing.md
@@ -45,7 +45,7 @@ Then click _Test Your Request_ to run the trigger or action step. Zapier will no
 
 Testing inside the visual builder is crucial to building functioning integrations. But to ensure people can easily use your integration, it's equally crucial to test your integration inside Zapier with live Zaps.
 
-To test your integration, make a Zap as normal at [zapier.com/app/editor](https://zapier.com/app/editor/), and choose your app in the _Choose App_ selector. Your integration will show the name and logo set in visual builder, along with the integration's current version number and a _By invite_ tag. If your integration is a new version of an existing integration, look for the latest version number and the _By invite_ tag to differentiate from existing, public integrations.
+To test your integration, make a Zap in the [Zap editor](https://zapier.com/app/editor/), and choose your app in the _Choose App_ selector. Your integration will show the name and logo set in visual builder, along with the integration's current version number and a _By invite_ tag. If your integration is a new version of an existing integration, look for the latest version number and the _By invite_ tag to differentiate from existing, public integrations.
 
 Then be sure to check each of the following:
 
@@ -69,16 +69,16 @@ When testing in the editor, use your integration's _Monitoring_ page to ensure t
 
 ## How to Invite Others to Test New Integrations
 
-![Zapier integration admins](https://cdn.zapier.com/storage/photos/5db3a5364349cbb17812e02e1eeddf11_2.png)
+It's crucial to have as many people test your integration as possible before launching it to the public. Integrations are required to have at least 3 users with live Zaps before they can be released. Each additional tester helps ensure that your app doesn't ship with usability problems or bugs.
 
-It's crucial to have as many people test your integration as possible before launching it to the public. Integrations are required to have at least 10 users with live Zaps before they can be released. Each additional tester helps ensure that your app doesn't ship with usability problems or bugs.
+![Zapier integration admins](https://cdn.zapier.com/storage/photos/5db3a5364349cbb17812e02e1eeddf11_2.png)
 
 While developing your app integration, invite additional admins from your integration's _Admins_ page. These users will have full access to your app's visual builder to edit the app details, authentication, triggers, actions, and versions. This is the best way to add additional developers to your project.
 
 ![Zapier integration visibility](https://cdn.zapier.com/storage/photos/c818563358f8566d969e9be09a560220.png)
 
-When your integration is nearly finished and ready for wider testing, you can invite testers from your integration's _Visibility_ page. These testers will be able to use your integration inside the Zapier editor, but cannot change your app's core settings and functionality in visual builder. This is the best way to add non-technical team members, beta testers, and advanced users of your app to your integration, to build up the minimum user count before launching your integration.
+When your integration is nearly finished and ready for wider testing, you can invite testers from your integration's _Sharing_ page. These testers will be able to use your integration inside the Zapier editor, but cannot change your app's core settings and functionality in the Platform UI. This is the best way to add non-technical team members, beta testers, and advanced users of your app to your integration, to allow for additional testing before launching your integration.
 
 From the [_Monitoring_ page](#monitoring), you'll then see every action taken by your integration users. You can filter by user, see auth and trigger/action events, and see any errors that occur.
 
-The _Analytics_ tab in the visual builder also provides usage statistics, focusing on how many users each trigger and action has.
+The _Analytics_ tab in the visual builder provides usage statistics, focusing on how many users each trigger and action has.

--- a/docs/_docs/versions.md
+++ b/docs/_docs/versions.md
@@ -9,33 +9,31 @@ redirect_from: /docs/
 
 Your Zapier integration should be quite nice when first launched—minimal, perhaps, but with the basics covered. The app authentication will let users connect to your API, and the triggers and actions should get data to and from your API.
 
-Over time, though, things will change. Users will request new triggers and actions, or want to send and receive more data with your existing ones. You’ll add new features to your app and want to add them to your Zapier integration, too. And eventually, your API may change, and your Zapier integration’s authentication or API calls may need changed as well.
+Over time, though, things will change. Users will request new triggers and actions, or want to send and receive more data with your existing ones. You’ll add new features to your app and want to add them to your Zapier integration, too. And eventually, your API may change, and your Zapier integration’s authentication or API calls may need to be changed as well.
 
-That’s where versions come in. Zapier lets you create multiple versions of your integration to test and build new features without interrupting existing users. You can then release the new version to some users, ensure everything is working, and eventually migrate all of your users to the new version—and remove the old, original integration.
-
-Here’s how.
+That’s where versions come in. Zapier lets you create multiple versions of your integration to test and build new features without interrupting existing users. You can then release the new version to some users, ensure everything is working, and eventually migrate all of your users to the new version. After that, you can deprecate and remove the old version.
 
 ## Manage Integration Versions in Zapier
 
-![Zapier integratin versions](https://cdn.zapier.com/storage/photos/4294ed1a2f6c7e3980cb9ac9c43f8655.png)
+![Zapier integration versions](https://cdn.zapier.com/storage/photos/4294ed1a2f6c7e3980cb9ac9c43f8655.png)
 
-Zapier’s visual builder includes a _Versions_ tab in the left sidebar. New integrations only include the original `1.0.0` version, the same version that Zapier lists in the top left of the visual builder as your app’s current version.
+Zapier’s visual builder includes a _Versions_ tab in the left sidebar. New integrations provide a starter `1.0.0` version, and you can create others versions as needed.
 
-Click either the version number in the top left of your Zapier visual creator sidebar or the gear icon beside your version in the _Versions_ tab to make changes. You can _Clone_ your integration to make a new version based on the features you already added to your integration—then once that version is ready, you can _Promote_ the new version to have new users start using it.
+Click the gear icon beside a version in the _Versions_ tab to make changes. You can _Clone_ your integration to make a new version based on the features of an existing version. Once the new version is ready, you can _Promote_ the new version to have new users start using it.
 
 ## Clone Your Integration
 
 ![Clone Zapier integration](https://cdn.zapier.com/storage/photos/dca2130ce5dddca928519ad60130d35a.png)
 
-Creating a new version of your Zapier integration is easy as you never need to start over. Instead, to make a new version, always start by cloning an existing version. That lets you start with an exact copy of your integration where you can make the changes and additions you need.
+When creating a new version of your Zapier integration, you never need to start over. Instead, to make a new version, start by cloning an existing version. That lets you start with an exact copy of your integration where you can make the changes and additions you need.
 
-To make a Clone, click the version button in the top left of the Zapier visual creator sidebar or the gear icon in the _Versions_ tab, and select _Clone_. In the dialog, select the version to clone from (usually the most recent version, unless you want to roll back recent changes). Then choose what type of version you want to create:
+To clone a version, click the gear icon in the _Versions_ tab, and select _Clone_. In the dialog, select the version to clone from (usually the most recent version, unless you want to roll back recent changes). Then choose what type of version you want to create:
 
 - **Patch**: A `x.x.1` version, typically used to fix bugs and issues in existing integrations
 - **Minor**: A `x.1.x` version, typically to add new minor features to existing integrations
 - **Major**: A `2.x.x` version to launch a full new version of your integration with new triggers and or actions
 
-Once you clone the integration, you can directly click the _Edit_ button to tweak the new version of your integration, or click _Close_ to go back to your existing, active integration.
+Once you clone the integration, click the _Edit_ button to tweak the new version of your integration, or click _Close_ to go back to the _Versions_ tab.
 
 ## Edit a Version of Your Integration
 
@@ -43,7 +41,7 @@ Once you clone the integration, you can directly click the _Edit_ button to twea
 
 You can add, edit, and test features in your new integration version just as you did in the original version. All you need to do is switch between your integration versions to add changes to the new version, not the original.
 
-To edit a specific integration version, open the _Versions_ tab, click the gear icon beside the version you want to edit, and select _Edit_. You can then see anytime what version you’re editing from the version number in the top left of your Zapier visual editor sidebar.
+To edit a specific integration version, either select it from the upper left of the Platform UI sidebar, or open the _Versions_ tab, click the gear icon beside the version you want to edit, and select _Edit_. You can see  what version you’re editing from the version number in the top left of your Zapier visual editor sidebar anytime.
 
 You can also test any version of your integration from Zapier’s standard Zap editor. Search for your app name when adding a Zap step, and Zapier will show multiple entries on your account with the version number beside each. Select the newest one to test your new changes.
 
@@ -53,23 +51,27 @@ You can also test any version of your integration from Zapier’s standard Zap e
 
 Once you’ve added all the changes needed to your integration, you can start rolling it out to users to update their existing Zaps and let users make new Zaps with your new integration features.
 
-If you made a patch version with only minor, non-breaking changes, you can migrate existing users and Zaps to your new integration version. Select the _Migrate_ option on your new integration version, then choose which older version of your integration to move users from—and the new version to move them to. Finally, choose what percentage of users to migrate. Typically, Zapier recommends moving a small percentage of your users—perhaps 10 or 20%—to the new integration to make sure everything is working as expected. Once everything seem fine, you can migrate the remainder of your users to the new integration.
+If you made a patch version with only minor, non-breaking changes, you can migrate existing users and Zaps to your new integration version. Select the _Migrate_ option on your new integration version, then choose which older version of your integration to move users from, and the new version to move them to. Finally, choose what percentage of users to migrate. 
 
-Major versions of integrations—especially if authentication or API calls were changed and other breaking changes were added—will require users to re-create their Zaps with the new version of your integration. In that case, you won’t be able to migrate existing users but instead will need to promote the new version and deprecate the old one so new users and Zaps will be made with the new integration.
+Typically, Zapier recommends moving a small percentage of your users—perhaps 10 or 20%—to the new integration version to make sure everything is working as expected. Once everything looks good, you can migrate the remainder of your users to the new version.
+
+Major versions of integrations—especially if authentication or API calls were changed and other breaking changes were added—will require users to re-create their Zaps with the new version of your integration. In that case, you won’t be able to migrate existing users. Instead, you'll need to promote the new version and deprecate the old one so new users and Zaps will be made with the new integration.
 
 ## Promote a New Version of Your Integration
 
 You can also Promote your new integration version to make it the default version that Zapier shows to users when creating new Zaps. Select the _Promote_ button in your version settings to mark an integration as the new default version.
 
+If you're working with an integration that's currently private, the _Promote_ option isn't used. Instead, make sure users you'd like to test or move to the new integration version are [invited](./testing#how-to-invite-others-to-test-new-integrations) to that version, and encourage them to try it out.
+
 ## Deprecate an Older Version of Your Integration
 
 ![Deprecate Zapier integration version](https://cdn.zapier.com/storage/photos/dd6acdd75278ecd733a5f3945ea641a2.png)
 
-If you did introduce breaking changes to your integration and want existing users to switch to the new version, you can deprecate the old version. That will let your older integration and Zaps that use it continue to run—but they will include a `(Legacy)` tag in the Zapier editor to prompt users to re-build the Zap with the new integration. Additionally, when adding a new Zap step, Zapier will no longer recommend the older, deprecated version of your integration.
+If you did introduce breaking changes to your integration and want existing users to switch to the new version, you can deprecate the old version. That will let your older integration and Zaps that use it continue to run—but they will include a `(Legacy)` tag in the Zapier editor to prompt users to re-build the Zap with the new integration. Additionally, when adding a new Zap step, Zapier will no longer show the older, deprecated version of your integration as an option.
 
 To deprecate a version, select _Deprecate_ in the Versions menu, then select a date to deprecate the integration in the calendar drop-down. Choose a date between two weeks and a year from today, then click the _Deprecate_ button to confirm.
 
-Zapier will then show a yellow exclamation mark beside that version in your integration’s versions menu, showing the date it will be deprecated if you hover over it. You’ll also be able to see your user count as it goes down, switching from the old integration version to the new.
+Zapier then shows a yellow exclamation mark beside that version in your integration’s versions menu, showing the date it will be deprecated when you hover over it. You’ll also see your user count as it goes down, switching from the old integration version to the new.
 
 ## Delete Older Versions of Your Integration
 
@@ -77,4 +79,4 @@ Zapier will then show a yellow exclamation mark beside that version in your inte
 
 Once you’ve deprecated an integration version and it has no existing users, you can delete that version to clean up your Zapier integration.
 
-Click the _Delete_ button in your version’s gear menu, select _Really?_ when asked to confirm, and Zapier will remove that version of your integration. And since Zapier will only delete deprecated versions with no users, you never have to worry about accidentally removing a version with features you need.
+Click the _Delete_ button in your version’s gear menu, select _Really?_ when asked to confirm, and Zapier will remove that version of your integration. Since Zapier will only delete deprecated versions with no users, you never have to worry about accidentally removing a version that's in active use.

--- a/docs/_docs/versions.md
+++ b/docs/_docs/versions.md
@@ -17,7 +17,7 @@ That’s where versions come in. Zapier lets you create multiple versions of you
 
 ![Zapier integration versions](https://cdn.zapier.com/storage/photos/4294ed1a2f6c7e3980cb9ac9c43f8655.png)
 
-Zapier’s visual builder includes a _Versions_ page in the left sidebar. New integrations provide a starter `1.0.0` version, and you can create other versions as needed.
+Zapier’s Platform UI includes a _Versions_ page in the left sidebar. New integrations provide a starter `1.0.0` version, and you can create other versions as needed.
 
 Click the gear icon beside a version on the _Versions_ page to make changes. You can _Clone_ your integration to make a new version based on the features of an existing version. Once the new version is ready, you can _Promote_ the new version to have new users start using it.
 

--- a/docs/_docs/versions.md
+++ b/docs/_docs/versions.md
@@ -17,9 +17,9 @@ That’s where versions come in. Zapier lets you create multiple versions of you
 
 ![Zapier integration versions](https://cdn.zapier.com/storage/photos/4294ed1a2f6c7e3980cb9ac9c43f8655.png)
 
-Zapier’s visual builder includes a _Versions_ tab in the left sidebar. New integrations provide a starter `1.0.0` version, and you can create others versions as needed.
+Zapier’s visual builder includes a _Versions_ page in the left sidebar. New integrations provide a starter `1.0.0` version, and you can create other versions as needed.
 
-Click the gear icon beside a version in the _Versions_ tab to make changes. You can _Clone_ your integration to make a new version based on the features of an existing version. Once the new version is ready, you can _Promote_ the new version to have new users start using it.
+Click the gear icon beside a version on the _Versions_ page to make changes. You can _Clone_ your integration to make a new version based on the features of an existing version. Once the new version is ready, you can _Promote_ the new version to have new users start using it.
 
 ## Clone Your Integration
 
@@ -27,13 +27,13 @@ Click the gear icon beside a version in the _Versions_ tab to make changes. You 
 
 When creating a new version of your Zapier integration, you never need to start over. Instead, to make a new version, start by cloning an existing version. That lets you start with an exact copy of your integration where you can make the changes and additions you need.
 
-To clone a version, click the gear icon in the _Versions_ tab, and select _Clone_. In the dialog, select the version to clone from (usually the most recent version, unless you want to roll back recent changes). Then choose what type of version you want to create:
+To clone a version, click the gear icon in the _Versions_ page, and select _Clone_. In the dialog, select the version to clone from (usually the most recent version, unless you want to roll back recent changes). Then choose what type of version you want to create:
 
 - **Patch**: A `x.x.1` version, typically used to fix bugs and issues in existing integrations
 - **Minor**: A `x.1.x` version, typically to add new minor features to existing integrations
 - **Major**: A `2.x.x` version to launch a full new version of your integration with new triggers and or actions
 
-Once you clone the integration, click the _Edit_ button to tweak the new version of your integration, or click _Close_ to go back to the _Versions_ tab.
+Once you clone the integration, click the _Edit_ button to tweak the new version of your integration, or click _Close_ to go back to the _Versions_ page.
 
 ## Edit a Version of Your Integration
 
@@ -41,7 +41,7 @@ Once you clone the integration, click the _Edit_ button to tweak the new version
 
 You can add, edit, and test features in your new integration version just as you did in the original version. All you need to do is switch between your integration versions to add changes to the new version, not the original.
 
-To edit a specific integration version, either select it from the upper left of the Platform UI sidebar, or open the _Versions_ tab, click the gear icon beside the version you want to edit, and select _Edit_. You can see  what version you’re editing from the version number in the top left of your Zapier visual editor sidebar anytime.
+To edit a specific integration version, either select it from the upper left of the Platform UI sidebar, or open the _Versions_ page, click the gear icon beside the version you want to edit, and select _Edit_. You can see  what version you’re editing from the version number in the top left of the sidebar anytime.
 
 You can also test any version of your integration from Zapier’s standard Zap editor. Search for your app name when adding a Zap step, and Zapier will show multiple entries on your account with the version number beside each. Select the newest one to test your new changes.
 


### PR DESCRIPTION
This page is aimed at public apps, but version management is possible for private apps as well, except for Promotion, which is only meaningful for public apps. 

Added that as a note and did a general cleanup on the page.