### PR TITLE
[SUPPORTOOL-299] Update footer to point to Partner contact form

### DIFF
--- a/_layouts/post-toc.html
+++ b/_layouts/post-toc.html
@@ -13,7 +13,7 @@
         <section class="content">{{ content }}</section>
         <footer class="prev-next">{% include prev-next.html %}</footer>
               <hr>
-          <p><em>Have any feedback or questions? <a href="https://github.com/zapier/visual-builder/issues/new/choose" target="_blank">Let us know</a>.</em></p>
+		  <p><em>Need help? <a href="https://developer.zapier.com/contact" target="_blank">Tell us about your problem</a> and we’ll connect you with the right resource or contact support.</em></p>
     </main>
     {% include javascript.html %}
   </body>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -10,7 +10,7 @@
         <footer class="prev-next">
   	     {% include prev-next.html %}
   	      <hr>
-  	       <p><em>Have any feedback or questions? <a href="https://github.com/zapier/visual-builder/issues/new/choose" target="_blank">Let us know</a>.</em></p>
+		  <p><em>Need help? <a href="https://developer.zapier.com/contact" target="_blank">Tell us about your problem</a> and we’ll connect you with the right resource or contact support.</em></p>
         </footer>
       </div>
     </main>


### PR DESCRIPTION
## Summary
Change the footer text of the platform docs to point to the new Partner contact form rather than Github issues for this repo. 
