### PR TITLE
[SUPPORTESC-161] Lifecycle Planning: Update publishing instructions and screenshot

### DIFF
--- a/docs/_partners/lifecycle-planning.md
+++ b/docs/_partners/lifecycle-planning.md
@@ -99,15 +99,7 @@ Zapier's support team serves as frontline support for your Zapier integration. I
 
 Read our [App Review Guidelines](https://platform.zapier.com/partners/integration-review-guidelines) to help you better prepare your integration before submitting it for review.
 
-#### Legacy Web Builder
-
-Navigate to the Visibility tab for your app and click the _Make this App Public_ button.
-
-![](https://zappy.zapier.com/511FFD77-85D4-4B93-A7BC-C2D1F52624AC.png)
-
-#### Platform UI
-
-Navigate to the Publishing page for your app, fill out the form, and click _Submit for Review_.
+Then, navigate to the Publishing page for your app, fill out the form, and click _Submit for Review_.
 
 ![](https://cdn.zappy.app/0055e6014cceb63fdb90ad671eb13229.png)
 

--- a/docs/_partners/lifecycle-planning.md
+++ b/docs/_partners/lifecycle-planning.md
@@ -97,15 +97,21 @@ Zapier's support team serves as frontline support for your Zapier integration. I
 
 ### **4. Submit your integration for review by the Zapier team**
 
-Read our [App Review Guidelines](https://platform.zapier.com/partners/integration-review-guidelines) to help you better prepare your integration before submitting it for review. Navigate to the Visibility tab for your app and click the _Make this App Public_ button. Expect to hear from us within a week.
+Read our [App Review Guidelines](https://platform.zapier.com/partners/integration-review-guidelines) to help you better prepare your integration before submitting it for review.
 
-Legacy builder:
+#### Legacy Web Builder
+
+Navigate to the Visibility tab for your app and click the _Make this App Public_ button.
 
 ![](https://zappy.zapier.com/511FFD77-85D4-4B93-A7BC-C2D1F52624AC.png)
 
-New visual builder:
+#### Platform UI
 
-![](https://zappy.zapier.com/6193B587-6437-47E8-B0C1-47ABB4B05291.png)
+Navigate to the Publishing page for your app, fill out the form, and click _Submit for Review_.
+
+![](https://cdn.zappy.app/0055e6014cceb63fdb90ad671eb13229.png)
+
+Expect to hear from us within a week.
 
 <a id="early"></a>
 


### PR DESCRIPTION
The instructions here still had the legacy builder, which apps can no longer go public from, and used an older screenshot from the current builder. This PR updates us to the current builder's current behavior.