### PR TITLE
[PDE-2046] Update template links to Google Doc that exists

### DIFF
--- a/docs/_partner_success_stories/close.md
+++ b/docs/_partner_success_stories/close.md
@@ -60,7 +60,7 @@ In addition to promoting integration improvements, the Close team also puts time
 
 The team creates how-to articles for their help documentation that demonstrate how to set up automations for different use cases, such as how to use Close and Zapier to push daily activity reports to Slack or Google Sheets.
 
-*Publish your own Zapier help document.** Copy [this pre-made template](https://docs.google.com/document/d/1A_eNBcoy8V8aB1bkVdZ386_U4WD-GkLPRDSvNBu-cCQ/edit), customize it, and publish it in your knowledge base within 5 minutes.*
+*Publish your own Zapier help document.** Copy [this pre-made template](https://docs.google.com/document/d/1eg3CaU9ytf5QH38FuaxAyQgmFN2HYZFbBN7E3l9kZZg/edit), customize it, and publish it in your knowledge base within 5 minutes.*
 
 They link to the [Close landing page](https://zapier.com/apps/closeio/integrations) on Zapier site's from their [integration directory page](https://close.com/api/) to help Close users get started with the integration right away. 
 

--- a/docs/_partners/lifecycle-planning.md
+++ b/docs/_partners/lifecycle-planning.md
@@ -113,7 +113,7 @@ New visual builder:
 
 ### Your App is Now a Part of the Zapier Platform!
 
-Your app will be listed with a dedicated page in [Zapier's App Directory](https://zapier.com/apps).  All Zapier users can discover your app and start building Zaps with your integration.  Your new integration will feature a Beta tag when it's first published.  At this point you'll have access to build Zap Templates, which are the best way to help new users discover specific useful things they can do with your integration.
+Your app will be listed with a dedicated page in [Zapier's App Directory](https://zapier.com/apps). All Zapier users can discover your app and start building Zaps with your integration. Your new integration will feature a Beta tag when it's first published. At this point you'll have access to build Zap Templates, which are the best way to help new users discover specific useful things they can do with your integration.
 
 ### What's the Next Step?
 
@@ -137,7 +137,7 @@ See previous section on building and publishing a new integration.
 
 ### **2. Create 10 Zap Templates**
 
-As soon as your app is published and in beta you can and should begin creating and sharing Zap Templates.  This is a great way to help your users discover specific, useful things they can do with your integration.  We'll look for a least 10 of these in place before an official partnership launch.
+As soon as your app is published and in beta you can and should begin creating and sharing Zap Templates. This is a great way to help your users discover specific, useful things they can do with your integration. We'll look for a least 10 of these in place before an official partnership launch.
 
 _Estimated time to complete: 1-2 hours_
 
@@ -155,10 +155,9 @@ The Zapier team provides frontline support for your integration and, in order to
 
 ### **4. Reach 50 Users to Receive an Invite from the Zapier Team**
 
-While your integration is in beta, we'll monitor how it's performing. When your integration reaches 50 users, our team will get in touch to invite you to start the official partner program launch process. 
+While your integration is in beta, we'll monitor how it's performing. When your integration reaches 50 users, our team will get in touch to invite you to start the official partner program launch process.
 
 <a id="beta"></a>
-
 
 ### **5. Surface Your Zap Templates In Your Product and On _Your_ Site**
 
@@ -198,7 +197,7 @@ Make sure your users of your Zapier integration can get their questions answered
 
 ![](https://cdn.zapier.com/storage/photos/90186e0afa54eab0817ae1f66488d380.gif)
 
-We've put together [this template](https://docs.google.com/document/d/1A_eNBcoy8V8aB1bkVdZ386_U4WD-GkLPRDSvNBu-cCQ/edit) to help you get your page up quickly.
+We've put together [this template](https://docs.google.com/document/d/1eg3CaU9ytf5QH38FuaxAyQgmFN2HYZFbBN7E3l9kZZg/edit) to help you get your page up quickly.
 
 ### **7. Create a Marketing Campaign for The Integration's Launch**
 


### PR DESCRIPTION
For some reason the old Google Doc template no longer exists.

https://zapierorg.atlassian.net/browse/PDE-2406