### PR TITLE
SUPPORTESC-163: Update CLI v11 docs

### DIFF
--- a/docs/_cli_docs/cli.md
+++ b/docs/_cli_docs/cli.md
@@ -5,7 +5,7 @@ layout: post-toc
 redirect_from: /cli-docs/
 ---
 
-<!-- AUTO GENERATED, DO NOT EDIT -->
+<!-- AUTO GENERATED, DO NOT EDIT, COPY zapier-platform/packages/cli/docs/cli.md INSTEAD -->
 
 # Zapier CLI Reference
 
@@ -524,22 +524,23 @@ Admins will immediately lose write access to the integration. Subscribers won't 
 
 ## test
 
-> Test your integration via `npm test`.
+> Test your integration via the "test" script in your "package.json".
 
 **Usage**: `zapier test`
 
-This command is effectively the same as `npm test`, except we also validate your integration and set up the environment. We recommend using mocha as your testing framework.
+This command is a wrapper around `npm test` that also validates the structure of your integration and sets up extra environment variables.
+
+You can pass any args/flags after a `--`; they will get forwarded onto your test script.
 
 **Flags**
-* `-t, --timeout` | Set test-case timeout in milliseconds.  Defaults to `2000`.
-* `--grep` | Only run tests matching pattern.
-* `--skip-validate` | Forgo running `zapier validate` before `npm test`.
-* `--yarn` | Use yarn instead of npm.
+* `--skip-validate` | Forgo running `zapier validate` before tests are run. This will speed up tests if you're modifying functionality of an existing integration rather than adding new actions.
+* `--yarn` | Use `yarn` instead of `npm`. This happens automatically if there's a `yarn.lock` file, but you can manually force `yarn` if you run tests from a sub-directory.
 * `-d, --debug` | Show extra debugging output.
 
 **Examples**
 * `zapier test`
-* `zapier test -t 30000 --grep api --skip-validate`
+* `zapier test --skip-validate -- -t 30000 --grep api`
+* `zapier test -- -fo --testNamePattern "auth pass"`
 
 
 ## upload

--- a/docs/_cli_docs/docs.md
+++ b/docs/_cli_docs/docs.md
@@ -22,9 +22,9 @@ Our code is updated frequently. To see a full list of changes, look no further t
 
 This doc describes the latest CLI version (**11.0.0**), as of this writing. If you're using an older version of the CLI, you may want to check out these historical releases:
 
-- CLI Docs: [9.4.0](https://github.com/zapier/zapier-platform/blob/zapier-platform-cli@9.4.0/packages/cli/README.md), [8.4.2](https://github.com/zapier/zapier-platform/blob/zapier-platform-cli@8.4.2/packages/cli/README.md)
-- CLI Reference: [9.4.0](https://github.com/zapier/zapier-platform/blob/zapier-platform-cli@9.4.0/packages/cli/README.md), [8.4.2](https://github.com/zapier/zapier-platform/blob/zapier-platform-cli@8.4.2/packages/cli/README.md)
-- Schema Docs: [9.4.0](https://github.com/zapier/zapier-platform/blob/zapier-platform-schema@9.4.0/packages/schema/docs/build/schema.md), [8.4.2](https://github.com/zapier/zapier-platform/blob/zapier-platform-schema@8.4.2/packages/schema/docs/build/schema.md)
+- CLI Docs: [10.2.0](https://github.com/zapier/zapier-platform/blob/zapier-platform-cli@10.2.0/packages/cli/README.md), [9.4.2](https://github.com/zapier/zapier-platform/blob/zapier-platform-cli@9.4.2/packages/cli/README.md), [8.4.2](https://github.com/zapier/zapier-platform/blob/zapier-platform-cli@8.4.2/packages/cli/README.md)
+- CLI Reference: [10.2.0](https://github.com/zapier/zapier-platform/blob/zapier-platform-cli@10.2.0/packages/cli/docs/cli.md), [9.4.2](https://github.com/zapier/zapier-platform/blob/zapier-platform-cli@9.4.2/packages/cli/docs/cli.md), [8.4.2](https://github.com/zapier/zapier-platform/blob/zapier-platform-cli@8.4.2/packages/cli/docs/cli.md)
+- Schema Docs: [10.2.0](https://github.com/zapier/zapier-platform/blob/zapier-platform-schema@10.2.0/packages/schema/docs/build/schema.md), [9.4.2](https://github.com/zapier/zapier-platform/blob/zapier-platform-schema@9.4.2/packages/schema/docs/build/schema.md), [8.4.2](https://github.com/zapier/zapier-platform/blob/zapier-platform-schema@8.4.2/packages/schema/docs/build/schema.md)
 
 ## Getting Started
 


### PR DESCRIPTION
Regenerate docs from the zapier-platform repo. Related PR: https://github.com/zapier/zapier-platform/pull/377.