### PR TITLE
probably fix redirects

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,10 +1,9 @@
 # Settings
 title: Zapier Platform UI Documentation
 description: "Zapier Platform UI"
-url: "" # the base hostname & protocol for your site, e.g. http://example.com
+url: "https://platform.zapier.com" # the base hostname & protocol for your site, e.g. http://example.com
 markdown: kramdown
-baseurl: ""
-slack_invite_url: "https://join.slack.com/t/zapier-platform/shared_invite/enQtOTgyMjkzNDU1NjM5LWM1MGQ1YmY5ODgxNmM1NjIzZTk3NjNkMzFlZWExYzU2MDJjNTVmNDEzMWUzYjdlNmMzZGViMzE0YjhlOGIyZDA"
+baseurl: "" # intentionally left blank, site is served at root
 partner_api_invite_url: "https://zapier.typeform.com/to/atnWuF"
 
 plugins:


### PR DESCRIPTION
Fixes [PDE-2510](https://zapierorg.atlassian.net/browse/PDE-2510).

Normally, `platform.zapier.com/docs` should redirect to `platform.zapier.com/docs/zapier-intro`. But, when the `CNAME` was removed (for HTTPS reasons, see [slack](https://zapier.slack.com/archives/C5Z9BP4U9/p1622832930477800?thread_ts=1622831211.476100&cid=C5Z9BP4U9)), the redirect started defaulting to the github pages site, which is a 404. 

This is documented [here](https://github.com/jekyll/jekyll-redirect-from#prefix). I believe fixing `site.url` will get it working again; it's hard to test because it always worked locally.

I also removed the slack invite url that we no longer use. 