### PR TITLE
[INT-15697] Update integration ownership scenario to provide exception

### DIFF
--- a/docs/_partners/integration-review-guidelines.md
+++ b/docs/_partners/integration-review-guidelines.md
@@ -93,7 +93,7 @@ Here are some further scenarios of what integrations are permitted on the Zapier
 Here are some further scenarios of what integrations are prohibited from the Zapier Platform by integration status, ownership, and intention:
 
 * Integrations by developers who are building on an API they own but for a competing product with Zapier are prohibited from going public or being invite-only.
-* Integrations by developers who are building on a public API they do not own and do not have approval to use, that route traffic to their own servers are prohibited from going public or being invite-only. Exceptions apply when building on an approved third-party API.
+* Integrations by developers who are building on a public API they do not own, and route traffic to their own servers are prohibited from going public or being invite-only. Exceptions apply when building on an approved third-party API.
 * Integrations by developers who do not own the API used in the integration or who have not been given explicit permission by the owners of the API cannot be public.
 
 ### 2.2 Developer Information

--- a/docs/_partners/integration-review-guidelines.md
+++ b/docs/_partners/integration-review-guidelines.md
@@ -93,7 +93,7 @@ Here are some further scenarios of what integrations are permitted on the Zapier
 Here are some further scenarios of what integrations are prohibited from the Zapier Platform by integration status, ownership, and intention:
 
 * Integrations by developers who are building on an API they own but for a competing product with Zapier are prohibited from going public or being invite-only.
-* Integrations by developers who are building on a public API they do not own, and route traffic to their own servers are prohibited from going public or being invite-only. Exceptions apply when building on an approved third-party API.
+* Integrations by developers who are building on a public API they do not own, and routing traffic to their own servers are prohibited from going public or being invite-only. Exceptions apply when building on an approved third-party API.
 * Integrations by developers who do not own the API used in the integration or who have not been given explicit permission by the owners of the API cannot be public.
 
 ### 2.2 Developer Information

--- a/docs/_partners/integration-review-guidelines.md
+++ b/docs/_partners/integration-review-guidelines.md
@@ -93,7 +93,7 @@ Here are some further scenarios of what integrations are permitted on the Zapier
 Here are some further scenarios of what integrations are prohibited from the Zapier Platform by integration status, ownership, and intention:
 
 * Integrations by developers who are building on an API they own but for a competing product with Zapier are prohibited from going public or being invite-only.
-* Integrations by developers who are building on a public API they do not own, and routing traffic to their own servers are prohibited from going public or being invite-only.
+* Integrations by developers who are building on a public API they do not own and do not have approval to use, that route traffic to their own servers are prohibited from going public or being invite-only. Exceptions apply when building on an approved third-party API.
 * Integrations by developers who do not own the API used in the integration or who have not been given explicit permission by the owners of the API cannot be public.
 
 ### 2.2 Developer Information


### PR DESCRIPTION
[Alexis suggested](https://zapier.slack.com/archives/C4124H5DF/p1632266357126400?thread_ts=1632248178.118400&cid=C4124H5DF) we update the Integration Ownership part of the Integration Review Guidelines to fit the [new decision](https://coda.io/d/Integrations-Team_djhfQ4ItfBo/Allow-public-Partner-apps-using-WhatsApp-Business-API_suGWf#_lusNd) allowing apps (on certain conditions) using the WhatsApp Business API. 