### PR TITLE
[SUPPORTESC-298] Add deduplication info to current platform version docs

### DIFF
--- a/docs/_docs/constraints.md
+++ b/docs/_docs/constraints.md
@@ -100,7 +100,7 @@ _“Scripting payload too large ('n' bytes but max is 6291456bytes).”_ - ('n' 
 
 ## Timeouts and payload size (polling triggers)
 
-**Constraint:** When a user clicks the “On” button of a Zap, Zapier does some additional initialization that must be accomplished in 30 seconds. First, it tests the user’s authentication to your service. Then it uses the trigger's `perform` method to build a deduplication table of records, so that the Zap will not run for existing records. More on that process is [here](https://platform.zapier.com/legacy/dedupe). The payload returned from this request must also be less than 6 MB.
+**Constraint:** When a user clicks the “On” button of a Zap, Zapier does some additional initialization that must be accomplished in 30 seconds. First, it tests the user’s authentication to your service. Then it uses the trigger's `perform` method to build a deduplication table of records, so that the Zap will not run for existing records. More on that process is [here](./dedupe). The payload returned from this request must also be less than 6 MB.
 
 **Errors a user will see if constraint is hit:**
 

--- a/docs/_docs/dedupe.md
+++ b/docs/_docs/dedupe.md
@@ -2,7 +2,7 @@
 title: Deduplication
 order: 11
 layout: post-toc
-redirect_from: /legacy/
+redirect_from: /docs/
 ---
 
 # Trigger Data Deduplication

--- a/docs/_docs/dedupe.md
+++ b/docs/_docs/dedupe.md
@@ -77,13 +77,13 @@ On the next poll after the new to-do is created, the API returns all to-dos, but
 
 In order for this mechanism to work, the `id` field should always be supplied and unique among all items in the result. 
 
-Your API must also be able to return results in reverse-chronological order to make sure new/updated items can be found on the first page of results, as we don't fetch additional pages. [Wufoo is a great example](https://wufoo.github.io/docs/#form-entries) of an API that supports sorting on any field and direction.
+Your API must also be able to return results in reverse-chronological order to make sure new/updated items can be found on the first page of results, as Zapier polling triggers don't automatically fetch additional pages. [Wufoo is a great example](https://wufoo.github.io/docs/#form-entries) of an API that supports sorting on any field and direction.
 
 ## Custom or multiple ID fields
 
 What if the items your API returns do not have an `id` field? Or how would you go about adding a *Updated to-do* trigger to our to-do app? In both cases you would use [Code Mode](./faq#codemode) to modify the API response.
 
-Let's assume your to-do API has an endpoint to return to-dos sorted by `updatedAt` in descending direction. Here's an example of how you could add code to your trigger to incorporate the `updatedAt` value in the ID, so that Zapier recognizes a new update as a new item. Assuming that you have configured `options` with the appropriate API request URL and parameters:
+Let's assume your to-do API has an endpoint that can return to-dos sorted by `updatedAt` in descending direction. Here's an example of how you could add code to your trigger to incorporate the `updatedAt` value in the ID, so that Zapier recognizes a new update as a new item. Assuming that you have configured `options` with the appropriate API request URL and parameters:
 
 {% highlight javascript %}
 {% raw %}
@@ -111,4 +111,4 @@ One possible scenario could be:
 1. Fetch the first page, containing the oldest items, but also the total number of pages.
 2. Fetch the last page and reverse the order of the items before returning it.
 
-You should be cautious when adding additional requests to your custom code. All your requests and processing code for a trigger must [finish within 30 seconds](./constraints).
+You should be cautious when adding additional requests to your custom code. All your requests and processing code for a trigger must [finish within 30 seconds](./constraints#timeouts-triggers-1). It's not recommended to attempt to fetch all pages of results.

--- a/docs/_docs/dedupe.md
+++ b/docs/_docs/dedupe.md
@@ -1,0 +1,114 @@
+---
+title: Deduplication
+order: 11
+layout: post-toc
+redirect_from: /legacy/
+---
+
+# Trigger Data Deduplication
+
+> Zapier automatically deduplicates incoming trigger data for you, so that Zaps do not run multiple times on the same data, but you must be mindful of how it works. The important bits are outlined below!
+
+Deduplication tl;dr:
+
+*   Provide a unique `id` key.
+*   Sort reverse-chronologically by time created.
+
+An unfortunate artifact of [polling](,/triggers#polling) for new data is that polling usually returns many results, most of which Zapier has seen before. Since we don't want to trigger an action multiple times when an item in your API exists in multiple distinct polls, we must deduplicate the data.
+
+For example, say your endpoint returns a list of to-dos:
+
+{% highlight javascript %}
+{% raw %}
+[
+  {
+    "id": 7,
+    "created": "Mon, 25 Jun 2012 16:41:54 -0400",
+    "list_id": 1,
+    "description": "integrate our api with zapier",
+    "complete": false
+  },
+  {
+    "id": 6,
+    "created": "Mon, 25 Jun 2012 16:41:45 -0400",
+    "list_id": 1,
+    "description": "get published in zapier library",
+    "complete": false
+  }
+]
+{% endraw %}
+{% endhighlight %}
+
+When a Zap is turned on, we make an initial call to your API to retrieve existing data, and cache and store each `id` field in our database.
+
+After this, we will poll at an interval (based on a customer's plan) looking for changes against this cached list of `id`s.
+
+Now let's say the user created a new to-do:
+
+{% highlight javascript %}
+{% raw %}
+[
+  {
+    "id": 8,
+    "created": "Mon, 25 Jun 2012 16:42:09 -0400",
+    "list_id": 1,
+    "description": "re-do our api to support webhooks",
+    "complete": false
+  },
+  {
+    "id": 7,
+    "created": "Mon, 25 Jun 2012 16:41:54 -0400",
+    "list_id": 1,
+    "description": "integrate our api with zapier",
+    "complete": false
+  },
+  {
+    "id": 6,
+    "created": "Mon, 25 Jun 2012 16:41:45 -0400",
+    "list_id": 1,
+    "description": "get published in zapier library",
+    "complete": false
+  }
+]
+{% endraw %}
+{% endhighlight %}
+
+On the next poll after the new to-do is created, the API returns all to-dos, but only the first to-do with `id` equal to `8` will be seen as a new item. That particular JSON object will then be passed through to the action in the user's Zap. The others will be ignored, since we already have seen their ids. That's the essence of deduplication.
+
+In order for this mechanism to work, the `id` field should always be supplied and unique among all items in the result. 
+
+Your API must also be able to return results in reverse-chronological order to make sure new/updated items can be found on the first page of results, as we don't fetch additional pages. [Wufoo is a great example](https://wufoo.github.io/docs/#form-entries) of an API that supports sorting on any field and direction.
+
+## Custom or multiple ID fields
+
+What if the items your API returns do not have an `id` field? Or how would you go about adding a *Updated to-do* trigger to our to-do app? In both cases you would use [Code Mode](./faq#codemode) to modify the API response.
+
+Let's assume your to-do API has an endpoint to return to-dos sorted by `updatedAt` in descending direction. Here's an example of how you could add code to your trigger to incorporate the `updatedAt` value in the ID, so that Zapier recognizes a new update as a new item. Assuming that you have configured `options` with the appropriate API request URL and parameters:
+
+{% highlight javascript %}
+{% raw %}
+return z.request(options)
+  .then((response) => {
+    response.throwForStatus();
+    const results = response.json;
+    results.forEach(function(result) {
+      result.originalId = result.id;
+      result.id = result.id + '-' + result.updatedAt;
+    });
+    return results;
+  });
+{% endraw %}
+{% endhighlight %}
+
+Notice how the code preserves the original `id` value before setting `id` to a new combined value that is unique for every update of a to-do. This is useful to ensure that the original ID can still be used for other purposes, such as performing a search or associating records together.
+
+## Re-order items
+
+What if your API cannot order its results in reverse-chronological order? How would you fetch the last page if you don't know how many pages there might be? You can also use [Code Mode](./faq#codemode) to make additional requests, if necessary.
+
+One possible scenario could be:
+
+1. Fetch the first page, containing the oldest items, but also the total number of pages.
+2. Fetch the last page and reverse the order of the items before returning it.
+
+You should be cautious when adding additional requests to your custom code. All your requests and processing code for a trigger must [finish within 30 seconds](./constraints).

--- a/docs/_partners/integration-examples.md
+++ b/docs/_partners/integration-examples.md
@@ -160,7 +160,7 @@ We recommend you use [REST Hooks](https://platform.zapier.com/docs/triggers#rest
 
 Updated triggers should run whenever an item has new data added, or when relational data is added or removed. If you are using REST hook triggers, which we recommend, ensure that when relational data is reapplied your app sends Zapier that updated record.
 
-If you are using polling triggers, this may cause issues with [how Zapier perform deduplication](https://platform.zapier.com/legacy_web_builder/dedupe), as we don’t consider the status, stage, or tag to be newly applied to that contact anymore. You may need to customize your API call's code to add a timestamp to the id field you’re using for deduplication so that the Zap triggers anew.
+If you are using polling triggers, this may cause issues with [how Zapier performs deduplication](https://platform.zapier.com/docs/dedupe), as we don’t consider the status, stage, or tag to be newly applied to that contact anymore. You may need to customize your API call's code to add a timestamp to the id field you’re using for deduplication so that the Zap triggers each time the record is updated.
 
 ### Trigger Response Format
 

--- a/docs/_partners/integration-review-guidelines.md
+++ b/docs/_partners/integration-review-guidelines.md
@@ -185,7 +185,7 @@ Live Zaps with [polling triggers](https://platform.zapier.com/docs/triggers#poll
 * Return results from the polling URL in reverse chronological order by created date, so the most recently created or updated object is returned first. 
 * Return a sufficient amount of items from the polling endpoint. Generally, 100 items is plenty for most integrations, but there are be cases where it’s common for users to perform an action that would trigger more than 100+ records at once.
 * Use [pagination](https://platform.zapier.com/docs/triggers#how-to-use-pagination) on the trigger results if large amounts of data will be returned.
-* Each result should contain an explicit ‘id’ field for [deduplication](https://platform.zapier.com/legacy/dedupe#zapier-deduplication) from the polling endpoint. By default, the field called `id` will be used as the deduplication key if it exists. Otherwise Zapier looks for the shortest field key with `id` in the key name.
+* Each result should contain an explicit ‘id’ field for [deduplication](https://platform.zapier.com/docs/dedup) from the polling endpoint. By default, the field called `id` will be used as the deduplication key if it exists. Otherwise Zapier looks for the shortest field key with `id` in the key name.
 
 ### 4.6 REST Webhooks
 [REST hook-based triggers](https://platform.zapier.com/docs/triggers#rest-hook-trigger) are Zapier’s preferred implementation of triggers, since they fire immediately after the triggering action is performed. Here’s a [post](https://zapier.com/engineering/introducing-resthooksorg/) further describing why we and our mutual users prefer REST hook triggers over polling triggers.

--- a/docs/_partners/integration-review-guidelines.md
+++ b/docs/_partners/integration-review-guidelines.md
@@ -185,7 +185,7 @@ Live Zaps with [polling triggers](https://platform.zapier.com/docs/triggers#poll
 * Return results from the polling URL in reverse chronological order by created date, so the most recently created or updated object is returned first. 
 * Return a sufficient amount of items from the polling endpoint. Generally, 100 items is plenty for most integrations, but there are be cases where it’s common for users to perform an action that would trigger more than 100+ records at once.
 * Use [pagination](https://platform.zapier.com/docs/triggers#how-to-use-pagination) on the trigger results if large amounts of data will be returned.
-* Each result should contain an explicit ‘id’ field for [deduplication](https://platform.zapier.com/docs/dedup) from the polling endpoint. By default, the field called `id` will be used as the deduplication key if it exists. Otherwise Zapier looks for the shortest field key with `id` in the key name.
+* Each result should contain an explicit ‘id’ field for [deduplication](https://platform.zapier.com/docs/dedupe) from the polling endpoint. By default, the field called `id` will be used as the deduplication key if it exists. Otherwise Zapier looks for the shortest field key with `id` in the key name.
 
 ### 4.6 REST Webhooks
 [REST hook-based triggers](https://platform.zapier.com/docs/triggers#rest-hook-trigger) are Zapier’s preferred implementation of triggers, since they fire immediately after the triggering action is performed. Here’s a [post](https://zapier.com/engineering/introducing-resthooksorg/) further describing why we and our mutual users prefer REST hook triggers over polling triggers.


### PR DESCRIPTION
This new doc covers much the same ground as https://platform.zapier.com/legacy/dedupe, but updated for the current platform. That way, we aren't linking to information a legacy platform from the new one, and it gets some freshening up.