### PR TITLE
[SUPPORTESC-301] Fix sidebar ordering after adding dedupe page

### DIFF
--- a/docs/_docs/actions.md
+++ b/docs/_docs/actions.md
@@ -1,6 +1,6 @@
 ---
 title: Actions
-order: 11
+order: 12
 layout: post-toc
 redirect_from: /docs/
 ---

--- a/docs/_docs/advanced.md
+++ b/docs/_docs/advanced.md
@@ -1,6 +1,6 @@
 ---
 title: Advanced Features
-order: 14
+order: 15
 layout: post-toc
 redirect_from: /docs/
 ---

--- a/docs/_docs/constraints.md
+++ b/docs/_docs/constraints.md
@@ -1,6 +1,6 @@
 ---
 title: Zapier Operating Constraints
-order: 16
+order: 17
 layout: post-toc
 redirect_from: /platform_wide/
 ---

--- a/docs/_docs/export.md
+++ b/docs/_docs/export.md
@@ -1,6 +1,6 @@
 ---
 title: Export Project to CLI
-order: 21
+order: 22
 layout: post-toc
 redirect_from: /docs/
 ---

--- a/docs/_docs/faq.md
+++ b/docs/_docs/faq.md
@@ -1,6 +1,6 @@
 ---
 title: FAQs
-order: 17
+order: 18
 layout: post-toc
 redirect_from: /docs/
 ---

--- a/docs/_docs/glossary.md
+++ b/docs/_docs/glossary.md
@@ -1,6 +1,6 @@
 ---
 title: Glossary
-order: 18
+order: 19
 layout: post
 redirect_from: /docs/
 ---

--- a/docs/_docs/integration-checks-reference.md
+++ b/docs/_docs/integration-checks-reference.md
@@ -1,6 +1,6 @@
 ---
 title: Integration Checks Reference
-order: 22
+order: 24
 layout: post-toc
 redirect_from: /docs/
 ---

--- a/docs/_docs/knownissues.md
+++ b/docs/_docs/knownissues.md
@@ -1,6 +1,6 @@
 ---
 title: Known Issues & Top Tips
-order: 20
+order: 21
 layout: post-toc
 redirect_from: /docs/
 ---

--- a/docs/_docs/search-create.md
+++ b/docs/_docs/search-create.md
@@ -1,6 +1,6 @@
 ---
 title: Searches and Creates
-order: 12
+order: 13
 layout: post-toc
 redirect_from: /docs/
 ---

--- a/docs/_docs/testing.md
+++ b/docs/_docs/testing.md
@@ -1,6 +1,6 @@
 ---
 title: Testing
-order: 13
+order: 14
 layout: post-toc
 redirect_from: /docs/
 ---

--- a/docs/_docs/versions.md
+++ b/docs/_docs/versions.md
@@ -1,6 +1,6 @@
 ---
 title: Versions
-order: 15
+order: 16
 layout: post-toc
 redirect_from: /docs/
 ---

--- a/docs/_docs/vs.md
+++ b/docs/_docs/vs.md
@@ -1,6 +1,6 @@
 ---
 title: Zapier Platform UI vs CLI
-order: 19
+order: 20
 layout: post-toc
 redirect_from: /docs/
 ---


### PR DESCRIPTION
When I added the "Deduplication" doc at order 11 in #274, I neglected to shift the rest of these down a notch, resulting in it being placed after Actions instead of after Triggers, as intended. This PR fixes that issue.

Now:
![now](https://cdn.zappy.app/af08a217603921b97ba7305addd0d01c.png)

After fix:
![after fix](https://cdn.zappy.app/25aa2b402e068e065bc02ac661bb566b.png)

There are no other changes to the order after these updates. 👍🏻 