### PR TITLE
[PDE-3149] docs(ui): Update Integration Checks Reference Intro

### DIFF
--- a/docs/_docs/integration-checks-reference.md
+++ b/docs/_docs/integration-checks-reference.md
@@ -7,7 +7,14 @@ redirect_from: /docs/
 
 # Integration Checks Reference
 
-We run your integration through a set of automated checks to ensure it's working property and giving our users the best possible experience. To help better address a check in communication, each check is given a unique ID, consisting of a capital letter and three digits, such as `D001`.
+We run your integration through a set of automated checks to ensure it's working properly and giving our users (and yours) the best possible experience. 
+
+To [publish your integration](https://platform.zapier.com/partners/lifecycle-planning#3-publish-your-integration-to-the-app-directory), all Errors and Publishing Tasks should be validated. You can address any Warnings after [submitting your integration for review](https://platform.zapier.com/partners/lifecycle-planning#4-submit-your-integration-for-review-by-the-zapier-team).
+
+If your integration will remain private, it isn't necessary to clear validation checks. You can [invite others to test your integration](https://platform.zapier.com/docs/testing#how-to-invite-others-to-test-new-integrations)
+before publication.
+
+To help better address a check in communication, each check is given a unique ID, consisting of a capital letter and three digits, such as `D001`.
 
 You don't need to know the implication of the initial capitial letter. But if you're curious, they are:
 

--- a/docs/_docs/integration-checks-reference.md
+++ b/docs/_docs/integration-checks-reference.md
@@ -11,8 +11,7 @@ We run your integration through a set of automated checks to ensure it's working
 
 To [publish your integration](https://platform.zapier.com/partners/lifecycle-planning#3-publish-your-integration-to-the-app-directory), all Errors and Publishing Tasks should be validated. You can address any Warnings after [submitting your integration for review](https://platform.zapier.com/partners/lifecycle-planning#4-submit-your-integration-for-review-by-the-zapier-team).
 
-If your integration will remain private, it isn't necessary to clear validation checks. You can [invite others to test your integration](https://platform.zapier.com/docs/testing#how-to-invite-others-to-test-new-integrations)
-before publication.
+If your integration will remain private, it isn't necessary to clear validation checks. You can [invite others to test your integration](https://platform.zapier.com/docs/testing#how-to-invite-others-to-test-new-integrations) before publication.
 
 To help better address a check in communication, each check is given a unique ID, consisting of a capital letter and three digits, such as `D001`.
 


### PR DESCRIPTION
Update the Integration Checks Reference text (linked from the [Vatidate Integration text](https://cdn.zappy.app/36418d63437d3017c0fb7eb6b4f0f9a8.png) in the Platform UI) to make it more helpful, reflect that tests aren't enforced if the app will remain private, and that publication is possible with outstanding warnings (only publishing tasks are needed).

This is also a source of confusion for devs. We receive many escalations asking about warnings before publication and whether publishing tasks need to be clear if the app intends to remain private.

I decided to make the update here instead of the text in the Platform UI so that completing the checks would still be implicitly encouraged, but devs will still find the extra details when they click on learn more.