### PR TITLE
[SUPPORTESC-350] Remove erroneous backtick

### DIFF
--- a/docs/_docs/input-designer.md
+++ b/docs/_docs/input-designer.md
@@ -108,7 +108,7 @@ For example, if our API expected a value of `1` or `2`, but `1` actually means `
   {
     "sample": "2",
     "value": "2",
-    "label": "Fish"`
+    "label": "Fish"
   }
 ]
 ```


### PR DESCRIPTION
Looks like a backtick (`) accidentally made its way into the example code for a dropdown menu, making it awkward if someone copy/pastes it into their integration before editing. Removing it makes the example valid JSON again.