### PR TITLE
[SUPPORTENG-393] Auth: updates related to Connection Label

### DIFF
--- a/docs/_docs/advanced.md
+++ b/docs/_docs/advanced.md
@@ -99,7 +99,7 @@ Commonly used authData fields include:
 
 Referenced with: {% raw %}`{{bundle.inputData.field}}`{% endraw %}
 
-In authentication fields and connection labels, `inputData` contains the output fields returned from the test API call, typically used to add a label to new integration connections, as well as some values provided by intermediate steps in more complex auth flows, such as the OAuth 2 `redirect_uri`.
+In authentication configuration, including connection labels, `inputData` contains the fields returned from the test API call, as well as some values provided by intermediate steps in more complex auth flows, such as the OAuth 2 `redirect_uri`. Values returned by the test API call are typically used to add a [connection label](./auth#label) to new integration connections.
 
 In triggers and actions, `inputData` contains the data that users enter into the input forms, with {% raw %}`{{curlies}}`{% endraw %} (mapped fields from previous Zap steps) rendered with their raw data. Zapier passes these inputs to the app for use with that trigger or action.
 

--- a/docs/_docs/advanced.md
+++ b/docs/_docs/advanced.md
@@ -87,7 +87,7 @@ Includes data users enter into the authentication input form, including the `use
 
 For example, the Access Token value will often accessed via {% raw %}`{{bundle.authData.access_token}}`{% endraw %} or {% raw %}`{{bundle.authData.accessToken}}`{% endraw %}.
 
-However, note that the `authData` bundle does not support nested objects: all values returned from auth functions need to be at the top level.
+However, note that the `authData` bundle does not support nested objects: all values returned from auth functions need to be at the top level. This bundle also does not include values provided by intermediate steps in OAuth2 or Session auth flows, like `redirect_uri`.
 
 Commonly used authData fields include:
 
@@ -99,7 +99,7 @@ Commonly used authData fields include:
 
 Referenced with: {% raw %}`{{bundle.inputData.field}}`{% endraw %}
 
-In authentication fields and connection labels, `inputData` contains the output fields returned from the test API call, typically used to add a label to new integration connections.
+In authentication fields and connection labels, `inputData` contains the output fields returned from the test API call, typically used to add a label to new integration connections, as well as some values provided by intermediate steps in more complex auth flows, such as the OAuth 2 `redirect_uri`.
 
 In triggers and actions, `inputData` contains the data that users enter into the input forms, with {% raw %}`{{curlies}}`{% endraw %} (mapped fields from previous Zap steps) rendered with their raw data. Zapier passes these inputs to the app for use with that trigger or action.
 

--- a/docs/_docs/apikey.md
+++ b/docs/_docs/apikey.md
@@ -81,14 +81,14 @@ If you need a custom API call, you can switch to code mode and write custom Java
 
 ![Zapier API Key auth connection label](https://cdn.zapier.com/storage/photos/f09f02450623750b70b67d0d7afa9e1c.png)
 
-Finally, add a connection label to help users identify each account that they add from your app to Zapier. Zapier includes your app's name in the connection label by default, followed by any text you include in the connection label. You can include:
+Finally, add a connection label to help users identify each account from your app that they connect with Zapier. Zapier includes your app's name in the connection label by default, followed by any text you include in the connection label. You can add:
 
 - Plain text that will be included in every account connection
 - Any input field from your authentication form
 - Output fields from your app's authentication test API call
 
-Do not use the API Key in the connection label, since it appears in plain text on Zapier. Yse identifiable, but non-sensitive, information. Learn more in our [Connection Label documentation](https://platform.zapier.com/docs/auth#label).
+Do not use the API Key in the connection label, since the label appears in plain text on Zapier. Yse identifiable, but non-sensitive, information. Learn more in our [Connection Label documentation](https://platform.zapier.com/docs/auth#label).
 
-Click _Save & Continue_ when finished to save your authentication settings.
+When you're finished, click _Save & Continue_ to save your authentication settings.
 
 Then, test your authentication, adding a real account to ensure Zapier can successfully connect to your app and use your test API call. Check our [Authentication Testing docs](https://platform.zapier.com/docs/auth#test) for more details, common errors you may encounter, and how to resolve those.

--- a/docs/_docs/apikey.md
+++ b/docs/_docs/apikey.md
@@ -87,7 +87,9 @@ Finally, add a connection label to help users identify each account from your ap
 - Any input field from your authentication form
 - Output fields from your app's authentication test API call
 
-Do not use the API Key in the connection label, since the label appears in plain text on Zapier. Yse identifiable, but non-sensitive, information. Learn more in our [Connection Label documentation](https://platform.zapier.com/docs/auth#label).
+Fields can be referenced using double curly braces. For example, a `username` field would look like {% raw %}`{{username}}`{% endraw %}. 
+
+Do not use the API Key in the connection label, since the label appears in plain text on Zapier. Use identifiable, but non-sensitive, information. Learn more in our [Connection Label documentation](https://platform.zapier.com/docs/auth#label).
 
 When you're finished, click _Save & Continue_ to save your authentication settings.
 

--- a/docs/_docs/apikey.md
+++ b/docs/_docs/apikey.md
@@ -81,13 +81,13 @@ If you need a custom API call, you can switch to code mode and write custom Java
 
 ![Zapier API Key auth connection label](https://cdn.zapier.com/storage/photos/f09f02450623750b70b67d0d7afa9e1c.png)
 
-Finally, add a connection label to help users identify each account that they add from your app to Zapier. Zapier includes your app's name in the connection label by default, followed by the version number, then any text you include in the connection label. You can include:
+Finally, add a connection label to help users identify each account that they add from your app to Zapier. Zapier includes your app's name in the connection label by default, followed by any text you include in the connection label. You can include:
 
 - Plain text that will be included in every account connection
-- Any input field from your authentication form—enter {% raw %}`{{bundle.authData.field}}`{% endraw %}, replacing `field` with your input form field key
-- Output fields from your app's authentication test API call, referenced with {% raw %}`{{bundle.inputData.field}}`{% endraw %} variables, replacing `field` for your API output field name
+- Any input field from your authentication form
+- Output fields from your app's authentication test API call
 
-Learn more in our [Connection Label documentation](https://platform.zapier.com/docs/auth#label).
+Do not use the API Key in the connection label, since it appears in plain text on Zapier. Yse identifiable, but non-sensitive, information. Learn more in our [Connection Label documentation](https://platform.zapier.com/docs/auth#label).
 
 Click _Save & Continue_ when finished to save your authentication settings.
 

--- a/docs/_docs/apikey.md
+++ b/docs/_docs/apikey.md
@@ -89,7 +89,7 @@ Finally, add a connection label to help users identify each account from your ap
 
 Fields can be referenced using double curly braces. For example, a `username` field would look like {% raw %}`{{username}}`{% endraw %}. 
 
-Do not use the API Key in the connection label, since the label appears in plain text on Zapier. Use identifiable, but non-sensitive, information. Learn more in our [Connection Label documentation](https://platform.zapier.com/docs/auth#label).
+**Do not use the API Key (or anything sensitive) in the connection label**, since the label appears in plain text on Zapier. Use identifiable, but non-sensitive, information. Learn more in our [Connection Label documentation](https://platform.zapier.com/docs/auth#label).
 
 When you're finished, click _Save & Continue_ to save your authentication settings.
 

--- a/docs/_docs/auth.md
+++ b/docs/_docs/auth.md
@@ -122,7 +122,13 @@ Click the _Edit Code_ button to switch to code mode. If the code mode is visible
 
 If you want to switch back to the regular field, click the _Delete Code_ button to delete your custom connection label code and revert to using the text entered in the connection label field.
 
-Use JavaScript to customize your connection label. When writing code for the connection label, fields are not pulled up to the top level - you must use `bundle.authData` for auth input fields, or `bundle.inputData` for fields returned from the test API request. 
+Use JavaScript to customize your connection label. When writing code for the connection label, fields are not pulled up to the top level - you must use `bundle.authData` for auth input fields, or `bundle.inputData` for fields returned from the test API request. For example, your code might look like this:
+
+```
+return `bundle.authData.username`;
+```
+
+This is equivalent to using {% raw %}`{{username}}` in the regular string mode.
 
 You can also add custom data to Zapier's console log with the `z.console.log` function to assist testing and monitoring your app authentication.
 

--- a/docs/_docs/auth.md
+++ b/docs/_docs/auth.md
@@ -27,9 +27,9 @@ Add authentication to your integration before adding triggers or actions. To do 
 ### [Basic Auth](https://platform.zapier.com/docs/basic)
 _As documented by [RFC 7616](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication)_
 
-Basic authentication lets users connect their accounts to Zapier with a username and password. Zapier then passes the provided credentials with each API call to authenticate the user. For Basic Auth, username and password are requested automatically, but you can also add additional fields if needed.
+Basic authentication lets users connect their accounts to Zapier with a username and password. Zapier passes the provided credentials with each API call to authenticate the user. For Basic Auth, username and password are requested automatically.
 
-The only other requirement is to add a test API call to confirm the credentials are valid.
+The only other requirement is to add a test API call to confirm the credentials are valid, but you can add additional input fields if needed.
 
 Only use Basic Auth if it's the only way to authenticate your API calls, as it requires Zapier to store users' credentials.
 
@@ -37,20 +37,20 @@ _→ [Add Basic Auth to your Zapier Integration](https://platform.zapier.com/doc
 
 ### [Session Auth](https://platform.zapier.com/docs/session)
 
-Session authentication also starts with users providing their app credentials. Using the credentials, Zapier makes an API call to a token exchange UR, and exchanges the credentials for an authentication token. The token is used to authenticate every subsequent API call.
+Session authentication also starts with users providing their app credentials. Using the credentials, Zapier makes an API call to a token exchange URL, and exchanges the credentials for an authentication token. The token is used to authenticate every subsequent API call.
 
 _→ [Add Session Auth to your Zapier Integration](https://platform.zapier.com/docs/session)_
 
 ### [API Key](https://platform.zapier.com/docs/apikey)
 
-API key authentication lets users provide an API key or similar credential from your app, along with any additional information, such as a domain. Zapier then passes the API key, along with any additional authentication details needed, to authenticate each API call.
+API key authentication lets users provide an API key or similar credential from your app, along with any additional information, such as a domain. Zapier then uses the API key and any additional details to authenticate each API call.
 
 _→ [Add API Key Auth to your Zapier Integration](https://platform.zapier.com/docs/apikey)_
 
 ### [OAuth v2](https://platform.zapier.com/docs/oauth)
 _Zapier's OAuth 2 implementation is based on the `authorization_code` flow, similar to [GitHub](https://developer.github.com/v3/oauth/) and [Facebook](https://developers.facebook.com/docs/authentication/server-side/)._
 
-OAuth 2.0 authentication lets users sign into app accounts and allow Zapier access via a popup window from that app. The app sends a request token before the user authenticates, which Zapier exchanges for an access token after they authenticate.
+OAuth 2.0 authentication lets users sign into app accounts and allow Zapier access via a popup window from that app. The app sends a request token when the user authenticates, which Zapier exchanges for an access token that's used to authenticate subsequent calls.
 
 Use OAuth 2.0 whenever possible, as it matches users' expectations for modern app authentication.
 
@@ -59,7 +59,7 @@ _→ [Add OAuth v2 Auth to your Zapier Integration](https://platform.zapier.com/
 ### [Digest Auth](https://platform.zapier.com/docs/digest)
 _As documented by [RFC 7616](https://tools.ietf.org/html/rfc7616)_
 
-Digest authentication lets users enter their username, password, and other required details for authentication in a Zapier-powered form. With every subsequent request, Zapier first makes an API call to request the nonce key before running the trigger or action's API call and including the encrypted authentication details and any other API call data to your app. Zapier handles the nonce and quality of protection details automatically.
+Digest authentication lets users enter their username, password, and other required details for authentication in a Zapier-powered form. With every subsequent request, Zapier first makes an API call to request the nonce key before running the trigger or action's API call. The encrypted authentication details and any other API call data are included in the request to your app. Zapier handles the nonce and quality of protection details automatically.
 
 _→ [Add Digest Auth to your Zapier Integration](https://platform.zapier.com/docs/digest)_
 

--- a/docs/_docs/auth.md
+++ b/docs/_docs/auth.md
@@ -13,21 +13,23 @@ Authentication allows Zapier access to an individual account in an app. Users co
 
 Once users authenticate their account on an app through Zapier, they can use any of that app's Zap steps without authenticating again. Users may also authenticate an app again if they wish to use additional accounts from an app with Zapier, typically to manage multiple projects or to use both work and personal accounts in workflows.
 
-When building a Zapier integration, you define how the Zapier platform connects to your app to authenticates users, and add an API call where Zapier can test the account authentication. You can then test that API call yourself and connect an account to Zapier, which you can then use to test any subsequent Zap Triggers and Actions you add to the integration.
+When building a Zapier integration, you define how the Zapier platform connects to your app to authenticate users, and add an API call where Zapier can test the account authentication. After configuring authentication, you can attempt to create a connection to your app on Zapier to validate the configuration. You can then use the connection to test any Zap Triggers and Actions you add to the integration.
 
 <a id="schemes"></a>
 ## Zapier Supported Authentication Schemes
 
 ![Zapier Authentication](https://cdn.zappy.app/728be35e4c32c7455185f582c60b059c.png)
 
-All Zapier integrations that can access or add private data for users require authentication. The only apps don't require authentication include data feeds (such as news or weather updates) or utilities (such as file format conversion tools or public search engines). If you're building an integration for any app that stores private data and requires an account to use , your integration will require authentication.
+All Zapier integrations that can access or add private data for users require authentication. The only apps that don't require authentication include data feeds (such as news or weather updates) or utilities (such as file format conversion tools or public search engines). If you're building an integration for any app that stores private data and requires an account to use, your integration will require authentication.
 
 Add authentication to your integration before adding triggers or actions. To do so, click the _Authentication_ tab in the left sidebar of Zapier's visual builder, then select the authentication scheme your app uses. Zapier supports the following five authentication schemes, each with their own settings:
 
 ### [Basic Auth](https://platform.zapier.com/docs/basic)
 _As documented by [RFC 7616](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication)_
 
-Basic authentication lets users connect their accounts to Zapier with a username and password through a pre-built form that Zapier then passes with each API call to authenticate the user. You only have to add a test API call to confirm the username and password are valid.
+Basic authentication lets users connect their accounts to Zapier with a username and password. Zapier then passes the provided credentials with each API call to authenticate the user. For Basic Auth, username and password are requested automatically, but you can also add additional fields if needed.
+
+The only other requirement is to add a test API call to confirm the credentials are valid.
 
 Only use Basic Auth if it's the only way to authenticate your API calls, as it requires Zapier to store users' credentials.
 
@@ -35,29 +37,29 @@ _→ [Add Basic Auth to your Zapier Integration](https://platform.zapier.com/doc
 
 ### [Session Auth](https://platform.zapier.com/docs/session)
 
-Session authentication lets users enter their username and password or other app credentials, with optional custom fields if needed for authentication. Zapier then makes an API call to a token exchange URL where Zapier exchanges the credentials for an authentication token, which Zapier will use to authenticate every subsequent API call.
+Session authentication also starts with users providing their app credentials. Using the credentials, Zapier makes an API call to a token exchange UR, and exchanges the credentials for an authentication token. The token is used to authenticate every subsequent API call.
 
 _→ [Add Session Auth to your Zapier Integration](https://platform.zapier.com/docs/session)_
 
 ### [API Key](https://platform.zapier.com/docs/apikey)
 
-API key authentication lets users enter a custom API key from your app, and can optionally request additional info such as a domain. Users will need to locate an API key from your app, then enter it in the Zapier authentication form. Zapier will then pass the API key, along with any additional authentication details needed, to authenticate each API call.
+API key authentication lets users provide an API key or similar credential from your app, along with any additional information, such as a domain. Zapier then passes the API key, along with any additional authentication details needed, to authenticate each API call.
 
 _→ [Add API Key Auth to your Zapier Integration](https://platform.zapier.com/docs/apikey)_
 
 ### [OAuth v2](https://platform.zapier.com/docs/oauth)
-_Same authentication flow as [Twitter](https://developer.twitter.com/en/docs/basics/authentication/overview) and [Trello](https://developers.trello.com/page/authorization)'s OAuth v2 implementation_
+_Zapier's OAuth 2 implementation is based on the `authorization_code` flow, similar to [GitHub](https://developer.github.com/v3/oauth/) and [Facebook](https://developers.facebook.com/docs/authentication/server-side/)._
 
-OAuth v2 authentication lets users sign into app accounts and allow Zapier access via a popup window from that app. The app sends a request token before the user authenticates, which Zapier then exchanges for an access token after they authenticate.
+OAuth 2.0 authentication lets users sign into app accounts and allow Zapier access via a popup window from that app. The app sends a request token before the user authenticates, which Zapier exchanges for an access token after they authenticate.
 
-Use OAuth v2 whenever possible, as it matches users expectations for modern app authentication.
+Use OAuth 2.0 whenever possible, as it matches users' expectations for modern app authentication.
 
 _→ [Add OAuth v2 Auth to your Zapier Integration](https://platform.zapier.com/docs/oauth)_
 
 ### [Digest Auth](https://platform.zapier.com/docs/digest)
 _As documented by [RFC 7616](https://tools.ietf.org/html/rfc7616)_
 
-Digest authentication lets users enter their username, password, and other required details for authentication in a Zapier-powered form. Then with every API call, Zapier first runs an API call to request the nonce key, before running the trigger or action's API call that passes the encrypted authentication details and any other API call data to your app. Zapier handles the nonce and quality of protection details automatically.
+Digest authentication lets users enter their username, password, and other required details for authentication in a Zapier-powered form. With every subsequent request, Zapier first makes an API call to request the nonce key before running the trigger or action's API call and including the encrypted authentication details and any other API call data to your app. Zapier handles the nonce and quality of protection details automatically.
 
 _→ [Add Digest Auth to your Zapier Integration](https://platform.zapier.com/docs/digest)_
 
@@ -69,25 +71,33 @@ _→ [Add Digest Auth to your Zapier Integration](https://platform.zapier.com/do
 ![Zapier connection labels](https://cdn.zapier.com/storage/photos/ed16e77428f17e869e25d4f2111df1c9.png)
 _A Zapier integration with a custom connection label (above) and without one (below)_
 
-Zapier lets users authenticate multiple accounts for any app. By default, every new app account added to Zapier is identified by the app's name followed by a number for secondary accounts.
+Zapier lets users authenticate multiple accounts for any app. By default, every new app account added to Zapier is identified by the app's name, followed by a number (#2, #3, ...) for accounts connected after the first.
 
-The connection label settings in your app's authentication options let you customize this account connection for your integration to include a username, email address, name, or other identifiable information in the connection label. That helps users distinguish between their authenticated accounts.
+The _Connection Label_ field in your app's authentication options let you customize this account connection for your integration to include a username, email address, name, or other identifiable information in the connection label. That helps users distinguish between their authenticated accounts.
 
 ![Zapier Authentication Connection Label](https://cdn.zapier.com/storage/photos/f2c3d557023ce2a65b41122da34c1fdd.png)
 
-Customize your app's connection label from the _Connection Label_ field in your Zapier integration. Zapier always includes the app's name in each account label. You can additionally include:
+Zapier always includes the app's name in each account label. You can add:
 
 - Plain text that will be included after your app's full name
-- Input fields with data users entered in the authentication form, referenced with {% raw %}`{{bundle.authData.field}}`{% endraw %} variables, replacing `field` for your input field name. With Basic auth, use `username` as the field.
-- Output fields from your app's authentication test API call, referenced with {% raw %}`{{bundle.inputData.field}}`{% endraw %} variables, replacing `field` for your API output field name.
+- Data that users entered in the authentication form.
+- Output fields from your app's authentication test API call.
 
-To add a connection label using an input field, enter the following in your _Connection Label_ field, optionally replacing `username` with the key for another input field your authentication form includes:
+To add a field value to the connection label, enter the name of the field, surrounded by double curly braces, in the _Connection Label_ field.
 
-{% raw %}`{{bundle.authData.username}}`{% endraw %}
+For example, if your auth configuration includes a `username` field, your connection label could look like:
 
-Alternately, you can use an output field from your test API call in the Connection Label if you know the name of the field you wish to use that your API sends to Zapier. Otherwise, skip adding the connection label first, and instead click _Connect an Account_ under step 2. Then click _Test Connected Account_ and check the _Response_ tab for a field that includes the data your app should use in the connection label. Finally, enter that field key in the following text instead of `field`, and add it to your _Connection Label_ field:
+{% raw %}`{{username}}`{% endraw %}
 
-{% raw %}`{{bundle.inputData.username}}`{% endraw %}
+Alternately, you can use an output field from your test API call in the Connection Label. If you aren't sure what fields will be returned, skip this step for now and go to Step 3, _Test your Authentication_.
+
+After connecting an account, check the _Response_ tab to see the fields returned from the test request. Then, return to Step 2, and enter that field key in the _Connection Label_ field. So if the field you want to use is called `team`, enter:
+
+{% raw %}`{{team}}`{% endraw %}
+
+When setting up a simple text connection label with dynamic fields, field keys from the authentication form and the test request are both pulled up to the top level, which is why simple field keys like `username` will work.
+ 
+You can also refer to the fields with {% raw %}`{{bundle.authData.field}}`{% endraw %} for input fields from the authentication form, replacing `field` with your input field name. Use {% raw %}`{{bundle.inputData.field}}`{% endraw %} for fields returned from the test request, replacing `field` with the field name from the API response.
 
 If you need to use a nested field from your API call results, reference it as `field.nestedfield`. For example, if your test API response includes a `name` field nested under `details`, you would reference it as:
 
@@ -100,17 +110,21 @@ You can include any field your authentication test API call returns in the conne
 
 ![Zapier connection label with code](https://cdn.zapier.com/storage/photos/e9bf3fdaabe078e43b38a402106c1456.png)
 
-You can customize your connection label further with JavaScript code, if needed. As before, Zapier will always include your app's name and integration version number first, followed by any text returned by your connection label code.
+You can customize your connection label further with JavaScript code if needed. Zapier will always include your app's name first, followed by any text returned by your connection label code.
 
-Custom code for connection labels are best used for:
+Custom code for connection labels is best used for:
 
 - Using code to manipulate data from an auth or test call before using it in a connection label, such as to format a number or date
 - Logging additional data to the authentication log
 - Making a new API call to access data to use in the connection label
 
-Click the _Edit Code_ button to switch to code mode. If the code mode is visible, Zapier will only use the code to create your connection label, and will ignore any existing text in the connection label field. If you wish to switch back to the regular field, click the _Delete Code_ button to delete your custom connection label code and revert to using the text entered in the connection label field.
+Click the _Edit Code_ button to switch to code mode. If the code mode is visible, Zapier will only use the code to create your connection label, and will ignore any existing text in the connection label field. 
 
-Use JavaScript to customize your connection label, and include data from authData or inputData bundles as normal. Additionally, you can add custom data to Zapier's console log with the `z.console.log` function to assist testing and monitoring your app authentication.
+If you want to switch back to the regular field, click the _Delete Code_ button to delete your custom connection label code and revert to using the text entered in the connection label field.
+
+Use JavaScript to customize your connection label. When writing code for the connection label, fields are not pulled up to the top level - you must use `bundle.authData` for auth input fields, or `bundle.inputData` for fields returned from the test API request. 
+
+You can also add custom data to Zapier's console log with the `z.console.log` function to assist testing and monitoring your app authentication.
 
 <a id="test"></a>
 ## How to Test Authentication
@@ -119,11 +133,11 @@ Use JavaScript to customize your connection label, and include data from authDat
 
 Once you've added the core details of how Zapier can authenticate users and test the connection, you need to try it out to set the final options. Click the _Connect an Account_ button to add your account with this app to Zapier.
 
-Zapier will open a popup window like one your users will see when authenticating your app with Zapier. Enter your account info or API key, or authenticate through your app's site, using real account details for a personal or testing account.
+Zapier will open a popup window (the same one your users will see) to prompt you to enter the necessarily information. Enter your account info or API key, or authenticate through your app's site, using real account details for a personal or testing account.
 
-> **Tip**: The account you add here will be the one you use to test any triggers and actions you add to Zapier in visual builder. It can also be used in live Zaps in Zapier, if you wish. These account details are not tied to your app definition, though, and if you add a collaborator to your Zapier integration, they will need to connect their own account for testing.
+> **Tip**: The account you add here will be the one you use to test any triggers and actions you add to Zapier. It can also be used in live Zaps in Zapier, if you wish. These account details are not tied to your app definition, though, and if you add a collaborator to your Zapier integration, they will need to connect their own account for testing.
 
-Once you've added your account, you'll see it with a connection label under the setup box. Then click _Test Connected Account_ to have Zapier run your testing API call and ensure your app connection works.
+Once you've added your account, you'll see it, with any connection label detail you added, under the setup box. Click _Test Connected Account_ to have Zapier run your testing API call.
 
 ![Example Zapier authentication test response](https://cdn.zapier.com/storage/photos/d5cf1a5cbc5a8389ad3272d01ef71c06.png)
 
@@ -131,7 +145,7 @@ If everything works as expected, Zapier will receive response data from the API 
 
 ![Example Zapier authentication error](https://cdn.zapier.com/storage/photos/3337e520ebab7b09de282e598ea70cfd.png)
 
-If something didn't work, Zapier will show the error message in the _Response_ tab, with the full response content in the _HTTP_ tab if you need more detail. Update your authentication settings accordingly, click the _Save & Continue_ button, then try testing your connected account again—and repeat until your authentication works and tests correctly.
+If something didn't work, Zapier will show the error message in the _Response_ tab, with the full response content in the _HTTP_ tab if you need more detail. Update your authentication settings accordingly, click the _Save & Continue_ button, then try testing your connected account again. Repeat until your authentication cobbects and tests correctly.
 
 With that, your app authentication should be finished, and your integration ready to add triggers and actions.
 
@@ -140,13 +154,13 @@ With that, your app authentication should be finished, and your integration read
 
 ![Zapier Remove Authentication Scheme](https://cdn.zapier.com/storage/photos/a84d330dce6ccc18cbdeb12ca555b12d.png)
 
-You cannot change an integration’s authentication scheme. Instead, remove an existing integration’s authentication then add a new authentication scheme.
+You cannot change an integration’s authentication scheme. Instead, remove an existing integration’s authentication, then add a new authentication scheme.
 
-To remove a Zapier integration's authentication scheme, open the _Authentication_ tab in the integration’s Zapier visual builder. Click the gear icon beside the existing authentication scheme, click _Delete_, then confirm to remove the authentication.
+To remove a Zapier integration's authentication scheme, open the _Authentication_ page. Click the gear icon beside the existing authentication scheme, click _Delete_, then confirm to remove the authentication.
 
 Then add your app’s new authentication scheme to the Zapier integration instead.
 
-> **Note:** Never remove authentication from an existing, live integration. If an integration’s authentication scheme needs changed, clone a new major version and add the new authentication. Then migrate users to the new version, and deprecate the original version with breaking changes. [Learn more](https://platform.zapier.com/docs/versions){:target="_blank"}
+> **Note:** Never remove authentication from an existing, live integration. If an integration’s authentication scheme needs to be changed, clone a new major version and add the new authentication. [Learn more](https://platform.zapier.com/docs/versions){:target="_blank"}
 
 <a id="error"></a>
 ## Common Authentication Error Messages
@@ -189,9 +203,9 @@ Try authenticating your app user account with Zapier again. Click _Connect an Ac
 The standard HTTP 400 `Bad Request` error is often returned when:
 
 - OAuth v2 Client ID and/or Secret are incorrect or expired
-- Some other part of your request, including the token request, are malformed
+- Some other part of your request is malformed, particularly a token exchange request
 
-Check the full error message from the error or Zapier's testing logs to see if it lists why the call failed, then correct that part of your authentication flow. Then double-check that each part of your authentication flow is entered correctly, including the request headers and body on each part of your authentication flow.
+Check the full error message from the error or Zapier's testing logs to see if it lists why the call failed, then correct that part of your authentication flow. Then double-check that each part of your authentication flow is entered correctly, including the request headers, URL parameters, and request body for each part of your authentication flow.
 
 ### Error Parsing Response
 
@@ -202,9 +216,9 @@ The _Error Parsing Response_ error is commonly returned when:
 - API returns non-standard and especially non-JSON output
 - Test API endpoint URL is incorrect
 
-Double-check the test API URL is entered correctly. If a standard, non-API endpoint URL is entered in the test field, the site will return its raw HTML page to Zapier and will result in this error. If you do change the URL, click _Save & Continue_ then test your connection again.
+Double-check that the test API URL is entered correctly. If a normal webpage URL is entered in the test field, the site will return its raw HTML content to Zapier and that will likely result in this error. If you do change the URL, click _Save & Continue_, then test your connection again.
 
-If your API call is correct and returning data in a format Zapier does not expect, you will need to switch to code mode and add custom parsing for your API response. Under the _Test_ API call in the top of your app's Authentication settings, click _Switch to Code Mode_, then add custom JavaScript code to parse your API response.
+If your API call is correct and returning data in a format Zapier does not expect, you will need to switch to [Code Mode](./faq#how-does-code-mode-work) and add custom parsing for your API response. Under the _Test_ API call in the top of your app's Authentication settings, click _Switch to Code Mode_, then add custom JavaScript code to parse your API response.
 
 ### Authentication Failed Task Timed Out
 
@@ -212,13 +226,12 @@ If your API call is correct and returning data in a format Zapier does not expec
 
 The _Authentication Failed_ error, often including _Task Timed Out_, is commonly returned when:
 
-- API request doesn't return a response to Zapier
-- API request response does not return within 30 seconds
-- API request is formatted incorrectly and the server does not respond with an error code
+- The API request does not return a response to Zapier within 30 seconds
+- The API request is formatted incorrectly and the server does not respond with an error code
 
 This error often shows up when authenticating a test account, as in the above screenshot. Check your Zapier test logs to see if it shows which URL timed out, then check to ensure you've entered the correct URL in all of your app authentication settings. Finally, check the API provider to see if their site or API are temporarily down.
 
-If the request seems to be successful but the task still times out, your API call may be taking too long to respond, or could be returning more data than Zapier can parse within the time limit. Try to use a testing API call in authentication that returns as little data as possible, such as a `/me` call that returns user account data. Or, if your API supports pagination and/or filtering, enable that and have the API return only the most recent result. Then test again to ensure the call works successfully.
+If the request seems to be successful but the task still times out, your API call may be taking too long to respond, or could be returning more data than Zapier can parse within the time limit. Try to use a testing API call in authentication that returns as little data as possible, such as a `/me` call that returns the connected user's account data. Or, if your API supports pagination and/or filtering, enable that and have the API return only the most recent result. Then test again to ensure the call works successfully.
 
 ### 500
 

--- a/docs/_docs/auth.md
+++ b/docs/_docs/auth.md
@@ -37,7 +37,7 @@ _→ [Add Basic Auth to your Zapier Integration](https://platform.zapier.com/doc
 
 ### [Session Auth](https://platform.zapier.com/docs/session)
 
-Session authentication also starts with users providing their app credentials. Using the credentials, Zapier makes an API call to a token exchange URL, and exchanges the credentials for an authentication token. The token is used to authenticate every subsequent API call.
+Session authentication also starts with users providing their app credentials, such as their username and password. Using the credentials, Zapier makes an API call to a token exchange URL, and exchanges the credentials for an authentication token. The token is used to authenticate every subsequent API call.
 
 _→ [Add Session Auth to your Zapier Integration](https://platform.zapier.com/docs/session)_
 
@@ -80,8 +80,8 @@ The _Connection Label_ field in your app's authentication options lets you custo
 Zapier always includes the app's name in each account label. You can add:
 
 - Plain text that will be included after your app's full name
-- Data that users entered in the authentication form.
-- Output fields from your app's authentication test API call.
+- Data that users entered in the authentication form
+- Output fields from your app's authentication test API call
 
 To add a field value to the connection label, enter the name of the field, surrounded by double curly braces, in the _Connection Label_ field.
 
@@ -122,10 +122,10 @@ Click the _Edit Code_ button to switch to [Code Mode](./faq#how-does-code-mode-w
 
 If you want to switch back to the regular field, click the _Delete Code_ button to delete your custom connection label code and revert to using the text entered in the _Connection Label_ field.
 
-When writing code for the connection label, fields are not pulled up to the top level - you must use `bundle.authData` for auth input fields, or `bundle.inputData` for fields returned from the test API request. For example, your code might look like this:
+When writing code for the connection label, fields are not pulled up to the top level of  the `bundle` object - you must use `bundle.authData` for auth input fields, or `bundle.inputData` for fields returned from the test API request. For example, your code might look like this:
 
 ```
-return `bundle.authData.username`;
+return bundle.authData.username;
 ```
 
 This is equivalent to using {% raw %}`{{username}}`{% endraw %} in the regular string mode.

--- a/docs/_docs/auth.md
+++ b/docs/_docs/auth.md
@@ -13,7 +13,7 @@ Authentication allows Zapier access to an individual account in an app. Users co
 
 Once users authenticate their account on an app through Zapier, they can use any of that app's Zap steps without authenticating again. Users may also authenticate an app again if they wish to use additional accounts from an app with Zapier, typically to manage multiple projects or to use both work and personal accounts in workflows.
 
-When building a Zapier integration, you define how the Zapier platform connects to your app to authenticate users, and add an API call where Zapier can test the account authentication. After configuring authentication, you can attempt to create a connection to your app on Zapier to validate the configuration. You can then use the connection to test any Zap Triggers and Actions you add to the integration.
+When building a Zapier integration, you define how the Zapier platform connects to your app to authenticate users, and add an API call where Zapier can test the account authentication. After configuring authentication, you can attempt to create a connection to your app on Zapier to validate the configuration. You can then use the connection to test any Triggers and Actions you add to the integration.
 
 <a id="schemes"></a>
 ## Zapier Supported Authentication Schemes
@@ -50,7 +50,7 @@ _→ [Add API Key Auth to your Zapier Integration](https://platform.zapier.com/d
 ### [OAuth v2](https://platform.zapier.com/docs/oauth)
 _Zapier's OAuth 2 implementation is based on the `authorization_code` flow, similar to [GitHub](https://developer.github.com/v3/oauth/) and [Facebook](https://developers.facebook.com/docs/authentication/server-side/)._
 
-OAuth 2.0 authentication lets users sign into app accounts and allow Zapier access via a popup window from that app. The app sends a request token when the user authenticates, which Zapier exchanges for an access token that's used to authenticate subsequent calls.
+OAuth 2.0 authentication lets users sign into app accounts and allow Zapier access via a popup window from that app. The app sends an authorization code when the user authenticates, which Zapier exchanges for an access token that's used to authenticate subsequent calls.
 
 Use OAuth 2.0 whenever possible, as it matches users' expectations for modern app authentication.
 
@@ -73,7 +73,7 @@ _A Zapier integration with a custom connection label (above) and without one (be
 
 Zapier lets users authenticate multiple accounts for any app. By default, every new app account added to Zapier is identified by the app's name, followed by a number (#2, #3, ...) for accounts connected after the first.
 
-The _Connection Label_ field in your app's authentication options let you customize this account connection for your integration to include a username, email address, name, or other identifiable information in the connection label. That helps users distinguish between their authenticated accounts.
+The _Connection Label_ field in your app's authentication options lets you customize the account connections for your integration to include a username, email address, name, or other identifiable information in the connection label. That helps users distinguish between their authenticated accounts.
 
 ![Zapier Authentication Connection Label](https://cdn.zapier.com/storage/photos/f2c3d557023ce2a65b41122da34c1fdd.png)
 
@@ -115,22 +115,22 @@ You can customize your connection label further with JavaScript code if needed. 
 Custom code for connection labels is best used for:
 
 - Using code to manipulate data from an auth or test call before using it in a connection label, such as to format a number or date
-- Logging additional data to the authentication log
+- Logging additional data
 - Making a new API call to access data to use in the connection label
 
-Click the _Edit Code_ button to switch to code mode. If the code mode is visible, Zapier will only use the code to create your connection label, and will ignore any existing text in the connection label field. 
+Click the _Edit Code_ button to switch to [Code Mode](./faq#how-does-code-mode-work). If the Code Mode is active, Zapier will only use the code to create your connection label, and will ignore any text that was in the _Connection Label_ field in the regular string mode. 
 
-If you want to switch back to the regular field, click the _Delete Code_ button to delete your custom connection label code and revert to using the text entered in the connection label field.
+If you want to switch back to the regular field, click the _Delete Code_ button to delete your custom connection label code and revert to using the text entered in the _Connection Label_ field.
 
-Use JavaScript to customize your connection label. When writing code for the connection label, fields are not pulled up to the top level - you must use `bundle.authData` for auth input fields, or `bundle.inputData` for fields returned from the test API request. For example, your code might look like this:
+When writing code for the connection label, fields are not pulled up to the top level - you must use `bundle.authData` for auth input fields, or `bundle.inputData` for fields returned from the test API request. For example, your code might look like this:
 
 ```
 return `bundle.authData.username`;
 ```
 
-This is equivalent to using {% raw %}`{{username}}` in the regular string mode.
+This is equivalent to using {% raw %}`{{username}}`{% endraw %} in the regular string mode.
 
-You can also add custom data to Zapier's console log with the `z.console.log` function to assist testing and monitoring your app authentication.
+You can also add custom data to Zapier's console log with the `z.console.log` function to assist with testing and monitoring your app authentication.
 
 <a id="test"></a>
 ## How to Test Authentication
@@ -139,19 +139,19 @@ You can also add custom data to Zapier's console log with the `z.console.log` fu
 
 Once you've added the core details of how Zapier can authenticate users and test the connection, you need to try it out to set the final options. Click the _Connect an Account_ button to add your account with this app to Zapier.
 
-Zapier will open a popup window (the same one your users will see) to prompt you to enter the necessarily information. Enter your account info or API key, or authenticate through your app's site, using real account details for a personal or testing account.
+Zapier will open a popup window (the same one your users will see) to prompt you to enter the necessary information. Enter your account info or API key, or authenticate through your app's site, using real account details for a personal or testing account.
 
-> **Tip**: The account you add here will be the one you use to test any triggers and actions you add to Zapier. It can also be used in live Zaps in Zapier, if you wish. These account details are not tied to your app definition, though, and if you add a collaborator to your Zapier integration, they will need to connect their own account for testing.
+> **Tip**: The account you add here will be the one you use to test any triggers and actions you add to Zapier. It can also be used in live Zaps in Zapier, if you wish. These account details are not tied to your app definition, though -- they're tied to your user account. If you add a collaborator to your Zapier integration, they will need to connect their own account for testing.
 
-Once you've added your account, you'll see it, with any connection label detail you added, under the setup box. Click _Test Connected Account_ to have Zapier run your testing API call.
+If the connection attempt succeeds, you'll see the new account connection, with any connection label detail you added, under the setup box. Click _Test Connected Account_ to have Zapier run your testing API call and show the results.
 
 ![Example Zapier authentication test response](https://cdn.zapier.com/storage/photos/d5cf1a5cbc5a8389ad3272d01ef71c06.png)
 
-If everything works as expected, Zapier will receive response data from the API call and display it in the _Response_ tab. You can look through the JSON-formatted fields from the response and use any of the field names in your account [connection label](#label). You can also look at the _Bundle_ tab to see the data Zapier used in the API request, and the _HTTP_ tab to see the full request and response details.
+If the test call works as expected, Zapier will receive response data from the API call and display it in the _Response_ tab. You can look through the JSON-formatted fields from the response and use any of the field names in your account [connection label](#label). You can also look at the _Bundle_ tab to see the data Zapier used in the API request, and the _HTTP_ tab to see the full request and response details.
 
 ![Example Zapier authentication error](https://cdn.zapier.com/storage/photos/3337e520ebab7b09de282e598ea70cfd.png)
 
-If something didn't work, Zapier will show the error message in the _Response_ tab, with the full response content in the _HTTP_ tab if you need more detail. Update your authentication settings accordingly, click the _Save & Continue_ button, then try testing your connected account again. Repeat until your authentication cobbects and tests correctly.
+If the connection attempt fails, no account connection will be created. Zapier will show the error message in the _Response_ tab, with the full response content in the _HTTP_ tab if you need more detail. Update your authentication settings accordingly, click the _Save & Continue_ button, then try testing your connection account again. Repeat until your authentication connects and tests correctly.
 
 With that, your app authentication should be finished, and your integration ready to add triggers and actions.
 

--- a/docs/_docs/basic.md
+++ b/docs/_docs/basic.md
@@ -80,9 +80,9 @@ If you need more customization, you can write custom JavaScript code to call you
 
 Finally, add a connection label to your Zapier integration. Zapier always includes the app's name in each account label. You can additionally include:
 
-- Plain text that will be included after your app's full name
-- The username that users enter in the Zapier authentication form when adding your app—enter {% raw %}`{{bundle.authData.username}}`{% endraw %} to include that
-- Output fields from your app's authentication test API call, referenced with {% raw %}`{{bundle.inputData.field}}`{% endraw %} variables, replacing `field` for your API output field name.
+- Plain text that will be included in every account connection
+- Any information that that users enter in the Zapier authentication form when adding your app, including the username
+- Output fields from your app's authentication test API call
 
 Learn more in our [Connection Label documentation](https://platform.zapier.com/docs/auth#label).
 

--- a/docs/_docs/basic.md
+++ b/docs/_docs/basic.md
@@ -84,6 +84,8 @@ Finally, add a connection label to your Zapier integration. Zapier always includ
 - Any information that that users enter in the Zapier authentication form when adding your app, including the username
 - Output fields from your app's authentication test API call
 
+Fields can be referenced using double curly braces. For example, the `username` field would look like {% raw %}`{{username}}`{% endraw %}. 
+
 Learn more in our [Connection Label documentation](https://platform.zapier.com/docs/auth#label).
 
 Click _Save & Continue_ when finished to save your authentication settings.

--- a/docs/_docs/basic.md
+++ b/docs/_docs/basic.md
@@ -81,7 +81,7 @@ If you need more customization, you can write custom JavaScript code to call you
 Finally, add a connection label to your Zapier integration. Zapier always includes the app's name in each account label. You can additionally include:
 
 - Plain text that will be included in every account connection
-- Any information that that users enter in the Zapier authentication form when adding your app, including the username
+- Any information that users enter in the Zapier authentication form when adding your app, such as the username
 - Output fields from your app's authentication test API call
 
 Fields can be referenced using double curly braces. For example, the `username` field would look like {% raw %}`{{username}}`{% endraw %}. 

--- a/docs/_docs/digest.md
+++ b/docs/_docs/digest.md
@@ -64,8 +64,8 @@ Enter an API endpoint that doesn't require additional detail or configuration, s
 Finally add a connection label to identify each account users add from your app to Zapier. Zapier includes your app's name in the connection label by default, followed by the version number, then any text you include in the connection label. You can include:
 
 - Plain text that will be included in every account connection
-- Any input field from your authentication form—enter {% raw %}`{{bundle.authData.field}}`{% endraw %}, replacing `field` with your input form field key. Use {% raw %}`{{bundle.authData.username}}`{% endraw %} to reference the default username field.
-- Output fields from your app's authentication test API call, referenced with {% raw %}`{{bundle.inputData.field}}`{% endraw %} variables, replacing `field` for your API output field name
+- Any input field from your authentication form
+- Output fields from your app's authentication test API call
 
 Learn more in our [Connection Label documentation](https://platform.zapier.com/docs/auth#label).
 

--- a/docs/_docs/digest.md
+++ b/docs/_docs/digest.md
@@ -67,6 +67,8 @@ Finally add a connection label to identify each account users add from your app 
 - Any input field from your authentication form
 - Output fields from your app's authentication test API call
 
+Fields can be referenced using double curly braces. For example, a `username` field would look like {% raw %}`{{username}}`{% endraw %}. 
+
 Learn more in our [Connection Label documentation](https://platform.zapier.com/docs/auth#label).
 
 Click _Save & Continue_ when finished to save your authentication settings.

--- a/docs/_docs/oauth.md
+++ b/docs/_docs/oauth.md
@@ -150,6 +150,8 @@ Finally add a connection label to help users identify each account that they add
 - Any input field from your authentication form (if present)
 - Output fields from your app's authentication test API call
 
+Fields can be referenced using double curly braces. For example, a `username` field would look like {% raw %}`{{username}}`{% endraw %}. 
+
 Learn more in our [Connection Label documentation](https://platform.zapier.com/docs/auth#label).
 
 Click _Save & Continue_ when finished to save your authentication settings.

--- a/docs/_docs/oauth.md
+++ b/docs/_docs/oauth.md
@@ -147,8 +147,8 @@ If you need a specialized API call or response parsing on this or other API call
 Finally add a connection label to help users identify each account that they add from your app to Zapier. Zapier includes your app's name in the connection label by default, followed by the version number, then any text you include in the connection label. You can include:
 
 - Plain text that will be included in every account connection
-- Any input field from your authentication form—enter {% raw %}`{{bundle.authData.field}}`{% endraw %}, replacing `field` with your input form field key
-- Output fields from your app's authentication test API call, referenced with {% raw %}`{{bundle.inputData.field}}`{% endraw %} variables, replacing `field` with your API output field name
+- Any input field from your authentication form (if present)
+- Output fields from your app's authentication test API call
 
 Learn more in our [Connection Label documentation](https://platform.zapier.com/docs/auth#label).
 

--- a/docs/_docs/session.md
+++ b/docs/_docs/session.md
@@ -85,11 +85,11 @@ As Session Auth doesn't include a defined standard for how access tokens are inc
 
 ![Example Session auth connection label](https://cdn.zapier.com/storage/photos/541510fff1e01b358f898b33f0ced5c2.png)
 
-Finally add a connection label to uniquely identify each account users add from your app to Zapier. Zapier includes your app's name in the connection label by default, followed by the version number, then any text you include in the connection label. You can include:
+Finally, add a connection label to uniquely identify each account users add from your app to Zapier. Zapier includes your app's name in the connection label by default, then any text you include in the connection label. You can include:
 
 - Plain text that will be included in every account connection
-- Any input field from your authentication form, or from your Token Exchange API call—enter {% raw %}`{{bundle.authData.field}}`{% endraw %}, replacing `field` with the input form field key or Token Exchange API call field
-- Output fields from your app's authentication test API call, referenced with {% raw %}`{{bundle.inputData.field}}`{% endraw %} variables, replacing `field` for your API output field name
+- Any input field from your authentication form, or output from your Token Exchange API call
+- Output fields from your app's authentication test API call
 
 Learn more in our [Connection Label documentation](https://platform.zapier.com/docs/auth#label).
 

--- a/docs/_docs/session.md
+++ b/docs/_docs/session.md
@@ -91,6 +91,8 @@ Finally, add a connection label to uniquely identify each account users add from
 - Any input field from your authentication form, or output from your Token Exchange API call
 - Output fields from your app's authentication test API call
 
+Fields can be referenced using double curly braces. For example, a `username` field would look like {% raw %}`{{username}}`{% endraw %}. 
+
 Learn more in our [Connection Label documentation](https://platform.zapier.com/docs/auth#label).
 
 Click _Save & Continue_ when finished to save your authentication settings.


### PR DESCRIPTION
The platform UI docs do have details about creating connection labels, but the hoisting we do to pull authData and inputData keys up to the top level wasn’t mentioned, even though it's used implicitly in some of the instructions. 

We also didn't mention that it didn’t apply in Code Mode, and a lot of emphasis was placed on the different bundle names, which isn’t strictly necessary given the hoisting.

My goal is to update the way we talk about data for connections labels so it’s consistent wherever it comes up, and refers back to the main section in the auth doc if appropriate.