### PR TITLE
[SUPPORTENG-446] Indent TOC sub-topics

### DIFF
--- a/_includes/toc.html
+++ b/_includes/toc.html
@@ -29,7 +29,7 @@
 
     {% capture my_toc %}{% endcapture %}
     {% assign orderedList = include.ordered | default: false %}
-    {% assign minHeader = include.h_min | default: 1 %}
+    {% assign minHeader = include.h_min | default: 2 %}
     {% assign maxHeader = include.h_max | default: 6 %}
     {% assign nodes = include.html | split: '<h' %}
     {% assign firstHeader = true %}

--- a/assets/stylesheets/components/_toc.scss
+++ b/assets/stylesheets/components/_toc.scss
@@ -21,6 +21,16 @@
     }
 
     strong { font-weight: 400; }
+
+    ul {
+      padding-left: 15px;
+      margin: 5px;
+
+      li::before {
+        content: "— ";
+      }
+
+    }
   }
 }
 


### PR DESCRIPTION
The current table of contents (TOC) sidebar lists all topics and subtopics in a single column, with no clear distinction between elements. That makes pages with many topics, like "Zapier Platform CLI Docs" (pictured below) difficult to parse.

![Zapier Platform CLI Docs](https://cdn.zappy.app/41c4724043ab4b63e3671614d71f2dc7.png)

This update adds an indentation and marker to all sub-topics, allowing for more clear delineation between topics. Additionally, it removes the top-level header from the TOC, as H1 is typically reserved for the page title. This allows each of a page's primary topic to be more prominent in the TOC. Example of the same doc with these changes applied pictured below.

![Zapier Platform CLI Docs with updates applied](https://cdn.zappy.app/e040db5d349d8ead64f453b7fb779ac6.png)