### PR TITLE
[SUPPORTENG-450] Add zoom function to images

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -26,3 +26,10 @@
     <div class="menu-toggle__icon" alt="Menu icon"></div>
   </button>
 </header>
+
+<!-- Image Zoom controls -->
+<div class="zoom-close">
+  <img src="../assets/images/toggle-close.svg" />
+</div>
+<div class="page-blur">
+</div>

--- a/_includes/javascript.html
+++ b/_includes/javascript.html
@@ -82,3 +82,42 @@ menuToggle.addEventListener('click', function(event) {
 
   _st('install', 'ZEr4Hw56b1TGkz2qViWp', '2.0.0');
 </script>
+
+<script>
+/* Image Zoom Feature */
+(() => {
+  const images = document.querySelectorAll(".content img");
+  const zoomClose = document.querySelector(".zoom-close");
+  const pageBlur = document.querySelector(".page-blur");
+
+  const toggleImageFocus = (e) => {
+    for (const image of images) {
+      if (image !== e.target) image.classList.remove("zoom");
+    }
+    e.target.classList.toggle("zoom");
+    zoomClose.classList.toggle("visible");
+    pageBlur.classList.toggle("visible");
+  }
+
+  const removeImageFocus = () => {
+    for (const image of images) {
+        image.classList.remove("zoom");
+    }
+    zoomClose.classList.remove("visible");
+    pageBlur.classList.remove("visible");
+  }
+
+  const keyDownHandler = (e) => {
+    if (e.key == "Escape") {
+      removeImageFocus();
+    }
+  }
+
+  for(const image of images) {
+    image.addEventListener("click", toggleImageFocus);
+  }
+  
+  zoomClose.addEventListener("click", removeImageFocus);
+  document.addEventListener("keydown", keyDownHandler);
+})();
+</script>

--- a/assets/stylesheets/base.scss
+++ b/assets/stylesheets/base.scss
@@ -16,6 +16,7 @@ $baseurl: "{{ site.baseurl }}";
 @import "elements/lists";
 @import "elements/button";
 @import "elements/tables";
+@import "elements/image-zoom";
 
 // Components
 @import "components/header";

--- a/assets/stylesheets/elements/_image-zoom.scss
+++ b/assets/stylesheets/elements/_image-zoom.scss
@@ -1,0 +1,47 @@
+img.zoom {
+    z-index: 998;
+    transform: translate(-50%,-50%);
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    max-width: 85vw;
+    max-height: 90vh;
+    width: auto;
+    height: auto;
+    cursor: pointer;
+}
+
+.zoom-close {
+    display: none;
+    position: fixed;
+    top: 15px;
+    right: 40px;
+    width: 50px;
+    height: 50px;
+    z-index: 999;
+    border-radius: 50%;
+    background: rgba(0,0,0,0.1);
+    cursor: pointer;
+}
+
+.zoom-close img {
+    position: absolute;
+    width: 70%;
+    height: 70%;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+}
+
+.page-blur {
+    display: none;
+    position: fixed;
+    z-index: 997;
+    background: rgba(0,0,0,0.75);
+    width: 100vw;
+    height: 100vh;
+}
+
+.visible {
+    display: block;
+}


### PR DESCRIPTION
The images in our documentation often have a lot of text, and while alt text is helpful for some users, the ability to zoom in on images would allow users that need it to ready that text more easily.

This update adds a basic zoom functionality to all images within the content of a document, activated by clicking on them. The zoom can then be cancelled by clicking the image again, clicking the "X" button, or using the escape key on a keyboard.

Example:

* Before zoom: https://cdn.zappy.app/14c83fe97b567499aa319869ad950654.png
* Zoom applied on click: https://cdn.zappy.app/d8f9b5b01fc0a00d065430f7c7dc28fe.png
* GIF of the zoom in action: https://cdn.zappy.app/27fb41c9355ac0c2e003f79863323544.gif

This addresses issue #195 