### PR TITLE
[PDE-2779] Distinction between bundle.inputData and bundle.authData.

### DIFF
--- a/docs/_cli_docs/docs.md
+++ b/docs/_cli_docs/docs.md
@@ -725,7 +725,7 @@ module.exports = App;
 
 ```
 
-> Note: For OAuth2, `authentication.oauth2Config.authorizeUrl`, `authentication.oauth2Config.getAccessToken`, and `authentication.oauth2Config.refreshAccessToken`  will have the provided fields in `bundle.inputData` instead of `bundle.authData` because `bundle.authData` will only have "previously existing" values, which will be empty when the user hasn't connected their account on your service to Zapier. Also note that `authentication.oauth2Config.getAccessToken` has access to the users return values in `rawRequest` and `cleanedRequest` should you need to extract other values (for example from the query string).
+> Note: For OAuth2, `authentication.oauth2Config.authorizeUrl` and `authentication.oauth2Config.getAccessToken` will have the provided fields in `bundle.inputData` instead of `bundle.authData` because `bundle.authData` will only have "previously existing" values, which will be empty when the user hasn't connected their account on your service to Zapier. `authentication.oauth2Config.refreshAccessToken` will have the provided fields in `bundle.authData` since the user would've connected their account when refreshing the access token. Also note that `authentication.oauth2Config.getAccessToken` has access to the users return values in `rawRequest` and `cleanedRequest` should you need to extract other values (for example from the query string).
 
 
 ## Resources


### PR DESCRIPTION
Make clear when to pull `bundle.inputData` and `bundle.authData` during different auth operations.