### PR TITLE
[SUPPORTENG-452] Add "Help" link to main nav

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -5,6 +5,7 @@
     <li><a href="https://zapier.com/platform/how-to-build">How to Build</a></li>
     <li><a href="https://zapier.com/platform/partner-program">Partner Program</a></li>
     <li><a href="/" class="platform-header__selected">Documentation</a></li>
+    <li><a href="https://developer.zapier.com/contact">Help</a></li>
   </ul>
 
   <div class="search">


### PR DESCRIPTION
This update adds a "Help" link to main navigation while viewing documentation, making it easier to access the developer contact form. This is similar to the recent update to developer.zapier.com (SUPPORTENG-448).

Before:

![Before](https://cdn.zappy.app/fd6054753f9a063911caacb39bdd591f.png)

After:

![After](https://cdn.zappy.app/b777aa18759f04dcb4f66c0034702437.png)