### PR TITLE
[SUPPORTENG-453] Replace Google Search plugin with internal solution

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ title: name
 order: 1
 layout: post
 redirect_from: /name/
+search_omit: false
 ---
 ```
 
@@ -128,7 +129,7 @@ Here's what this information means:
 - The `order: (number)` determines placement in the left navigation.
 - The `layout: post` is default, but you can add `layout: post-toc` which will add the table of contents on the right based on the `h2` you use.
 - The `redirect_from:` just put the name of the collection (e.g. _updates).
-
+- The `search_omit:` toggle tells the Search page whether this page should be excluded from results.
 #### Step 3
 Repeat to add more posts.
 

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -8,18 +8,9 @@
   </ul>
 
   <div class="search">
-    <script>
-      (function() {
-        var cx = '006212384688293188622:ae9ahilsbti';
-        var gcse = document.createElement('script');
-        gcse.type = 'text/javascript';
-        gcse.async = true;
-        gcse.src = 'https://cse.google.com/cse.js?cx=' + cx;
-        var s = document.getElementsByTagName('script')[0];
-        s.parentNode.insertBefore(gcse, s);
-      })();
-    </script>
-    <gcse:search></gcse:search>
+    <form method="get" action="/search" autocomplete="off">
+        <input type="text" name="q" class="search-input" placeholder="Search..." autofill="off" />
+    </form>
   </div>
 
   <button class="menu-toggle js-menu-toggle" aria-controls="menu" aria-expanded="true">

--- a/_includes/search.html
+++ b/_includes/search.html
@@ -27,20 +27,49 @@ const prettifyCollectionName = (name) => {
         .replace(/cli/gi, 'CLI');
 }
 
-const prettifyExcerpt = (page, query) => {
+const prettifyExcerpt = (post, query) => {
     let excerpt = "";
-    const firstAppearanceOfQuery = page.content.search(query);
-    let startOfExcerpt = page.content.indexOf(". ", Math.max(0, firstAppearanceOfQuery - 100)) + 1;
-    if (startOfExcerpt > firstAppearanceOfQuery) {
-        excerpt = "...";
-        startOfExcerpt = page.content.indexOf(" ", Math.max(0, firstAppearanceOfQuery - 100)) + 1;
+    let foundPartOfQuery = query;
+    let firstAppearanceOfQuery = 0;
+
+    const trimmedQuery = removeFillerWords(query.trim());
+    const queryTerms = trimmedQuery.split(' ');
+
+    /**
+    * Search for the first time our search query appears in
+    * the post content. If the whole query doesn't appear, 
+    * shorten the query until a part of it does.
+    */
+
+    const forwardSearch = queryTerms;
+    while (forwardSearch.length > 0) {
+        const searchFor = forwardSearch.join(' ');
+        const regex = new RegExp(searchFor, 'gi');
+        const searchPosition = post.content.search(regex);
+        if (searchPosition > -1) {
+            firstAppearanceOfQuery = searchPosition;
+            foundPartOfQuery = searchFor;
+            break;
+        }
+        forwardSearch.splice(0, 1);
     }
-    let endOfExcerpt = page.content.indexOf(".", firstAppearanceOfQuery + 100) + 1;
-    
-    const fullWord = new RegExp(`(\\w*(?:${query})\\w*)`, 'gi');
-    excerpt += page.content
-        .slice(startOfExcerpt, endOfExcerpt)
-        .replace(fullWord, "<b>$1</b>");
+
+    /**
+    * Find the paragraph around the query, so we can show it in context.
+    */ 
+    let startOfExcerpt = post.content.indexOf(". ", Math.max(0, firstAppearanceOfQuery - 100)) + 1;
+    if (startOfExcerpt > firstAppearanceOfQuery) {
+        excerpt = "... ";
+        startOfExcerpt = post.content.indexOf(" ", Math.max(0, firstAppearanceOfQuery - 100)) + 1;
+    }
+    let endOfExcerpt = post.content.indexOf(".", firstAppearanceOfQuery + 100) + 1;
+    excerpt += post.content.slice(startOfExcerpt, endOfExcerpt);
+
+    /**
+    * Bold the relevant words in the resulting excerpt, to make them stand out.
+    */ 
+    const completedWords = new RegExp(`(\\w*(?:${foundPartOfQuery})\\w*)`, 'gi');
+    excerpt = excerpt.replace(completedWords, "<b>$1</b>");
     
     return excerpt;
 }
@@ -62,22 +91,85 @@ const getPageTitle = (page) => {
     }
 }
 
+const removeFillerWords = (string) => {
+    /**
+    * Terms that might be searched for, but are so common in English that
+    * they'd return too many false positives.
+    */
+    const fillerTerms = ["and", "or", "for", "the", "but", "not", "is", "to", "how", "you", "my", "i", "a", "an"];
+    let newString = "";
+
+    for (const word of string.toLowerCase().split(' ')) {
+        if (fillerTerms.indexOf(word) == -1) {
+            newString += word + " ";
+        }
+    }
+
+    return newString.trim();
+}
+
 /**
 * Search functions
 */
 
+const matchStrength = (query, post) => {
+    /** 
+    * Returns a number representing the "strength" or "relevance"
+    * of a given search result, based on the number of times each
+    * word from the query appears in the post, with added points for 
+    * whole matches and matches in the post title.
+    */
+    let strength = 0;
+    const trimmedQuery = removeFillerWords(query.trim());
+    const queryTerms = trimmedQuery.split(' ');
+
+    /**
+    * Search through the content and title with the whole query,
+    * then remove the first term, repeating until there are no more terms.
+    */ 
+    const forwardSearch = queryTerms;
+    while (forwardSearch.length > 0) {
+        const regex = new RegExp(forwardSearch.join(' '), 'gi');
+        strength += [...post.content.matchAll(regex)].length * forwardSearch.length;
+        strength += [...post.title.matchAll(regex)].length * forwardSearch.length * 10;
+        forwardSearch.splice(0, 1);
+    }
+
+    /**
+    * Search through the content and title with the whole query,
+    * then remove the last term, repeating until there are no more terms.
+    */ 
+    const backwardSearch = queryTerms;
+    while (backwardSearch.length > 0) {
+        const regex = new RegExp(backwardSearch.join(' '), 'gi');
+        strength += [...post.content.matchAll(regex)].length * backwardSearch.length;
+        strength += [...post.title.matchAll(regex)].length * backwardSearch.length * 10;
+        backwardSearch.splice(-1, 1);
+    }
+
+    return strength;
+}
+
+const isMatch = (query, post) => {
+    const queryTerms = removeFillerWords(query.trim()).split(' ');
+    for (const term of queryTerms) {
+        const regex = new RegExp(term, "gi");
+        if (regex.test(post.content) || regex.test(post.title)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 const search = async (query) => {
     const content = await getAllContent();
-    const regex = new RegExp(query.trim(), "gi");
-    // TO-DO: Split the query and provide partial matches
     const searchResults = content
-        .filter((item) => {
-            return item.search_omit != "true" && (regex.test(item.title) || regex.test(item.content));
+        .filter((post) => {
+            return post.search_omit != "true" && isMatch(query, post);
         })
         .sort((a, b) => {
-            const relevanceA = a.title.matchAll(regex).length + a.content.matchAll(regex).length;
-            const relevanceB = b.title.matchAll(regex).length + b.content.matchAll(regex).length;
-            return relevanceB - relevanceA;
+            return matchStrength(query, b) - matchStrength(query, a);
         });
 
     searchDetailsElement.innerHTML = `Found <b>${searchResults.length}</b> results for <b>${query}</b>`;

--- a/_includes/search.html
+++ b/_includes/search.html
@@ -1,0 +1,102 @@
+<script>
+const jsonPath = '/search/content.json';
+const searchResultsElement = document.querySelector("#search-results");
+const searchInputElement = document.querySelector(".content .search .search-input");
+const searchDetailsElement = document.querySelector("#search-details");
+const urlSearchParams = new URLSearchParams(window.location.search);
+const params = Object.fromEntries(urlSearchParams.entries());
+
+/**
+* Helper functions
+*/
+
+const getAllContent = () => {
+    return fetch(jsonPath)
+    .then((response) => {
+        if (!response.ok) {
+            throw new Error(`HTTP error! Status: ${response.status}`);
+        }
+        return response.json();
+    });
+}
+
+const prettifyCollectionName = (name) => {
+    return name
+        .replace(/[\+\-\_]/g, ' ')
+        .replace(/^(\w)|\s(\w)/g, (w) => w.toUpperCase())
+        .replace(/cli/gi, 'CLI');
+}
+
+const prettifyExcerpt = (page, query) => {
+    let excerpt = "";
+    const firstAppearanceOfQuery = page.content.search(query);
+    let startOfExcerpt = page.content.indexOf(". ", Math.max(0, firstAppearanceOfQuery - 100)) + 1;
+    if (startOfExcerpt > firstAppearanceOfQuery) {
+        excerpt = "...";
+        startOfExcerpt = page.content.indexOf(" ", Math.max(0, firstAppearanceOfQuery - 100)) + 1;
+    }
+    let endOfExcerpt = page.content.indexOf(".", firstAppearanceOfQuery + 100) + 1;
+    
+    const fullWord = new RegExp(`(\\w*(?:${query})\\w*)`, 'gi');
+    excerpt += page.content
+        .slice(startOfExcerpt, endOfExcerpt)
+        .replace(fullWord, "<b>$1</b>");
+    
+    return excerpt;
+}
+
+const getPageTitle = (page) => {
+    /**
+    * Our docs technically have two titles:
+    * 1. The one set in each file's frontmatter
+    * 2. The first line of the content (usually an H1)
+    * Usually these are the same, but sometimes the second option
+    * provides more detail. This function tries to return the
+    * second option to display to the user.
+    */
+    const regex = /^(\w.+)\n/;
+    try {
+        return regex.exec(page.content)[0];
+    } catch {
+        return page.title;
+    }
+}
+
+/**
+* Search functions
+*/
+
+const search = async (query) => {
+    const content = await getAllContent();
+    const regex = new RegExp(query.trim(), "gi");
+    // TO-DO: Split the query and provide partial matches
+    const searchResults = content
+        .filter((item) => {
+            return item.search_omit != "true" && (regex.test(item.title) || regex.test(item.content));
+        })
+        .sort((a, b) => {
+            const relevanceA = a.title.matchAll(regex).length + a.content.matchAll(regex).length;
+            const relevanceB = b.title.matchAll(regex).length + b.content.matchAll(regex).length;
+            return relevanceB - relevanceA;
+        });
+
+    searchDetailsElement.innerHTML = `Found <b>${searchResults.length}</b> results for <b>${query}</b>`;
+    // TO-DO: Provide suggestions when no matches found
+
+    for (const result of searchResults) {
+        const div = document.createElement("div");
+        div.classList.add("result");
+        div.innerHTML = `<h2 class="search-result-title"><a href="${result.link}">${getPageTitle(result)}</a></h2><div class="search-result-details"><a class="search-result-collection" href="${result.collection}">${prettifyCollectionName(result.collection)}</a><blockquote class="search-result-text">${prettifyExcerpt(result, query)}</blockquote></div>`;
+        searchResultsElement.appendChild(div);
+    }
+}
+
+/**
+* Run the search
+*/
+
+if (params.q) {
+    searchInputElement.value = params.q;
+    search(params.q);
+}
+</script>

--- a/_includes/side-nav.html
+++ b/_includes/side-nav.html
@@ -4,18 +4,9 @@
 <div class="sidebar">
   <nav id="menu" class="sidebar__nav">
     <div class="search">
-      <script>
-        (function() {
-          var cx = '006212384688293188622:ae9ahilsbti';
-          var gcse = document.createElement('script');
-          gcse.type = 'text/javascript';
-          gcse.async = true;
-          gcse.src = 'https://cse.google.com/cse.js?cx=' + cx;
-          var s = document.getElementsByTagName('script')[0];
-          s.parentNode.insertBefore(gcse, s);
-        })();
-      </script>
-      <gcse:search></gcse:search>
+      <form method="get" action="/search" autocomplete="off">
+          <input type="text" name="q" class="search-input" placeholder="Search..." autofill="off" />
+      </form>
     </div>
     {% include side-nav-item.html title="Quick Start" items=site.quickstart section_id="quickstart" current_section=current_section %}
     {% include side-nav-item.html title="Documentation" items=site.docs section_id="docs" current_section=current_section %}

--- a/_layouts/search.html
+++ b/_layouts/search.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+{% include head.html %}
+  <body>
+    {% include header.html %}
+    <main class="split-layout">
+      {% include side-nav.html %}
+      <div class="container">
+        <section class="content">{{ content }}</section>
+        <section class="content">
+            <div class="search">
+                <form method="get" action="/search" autocomplete="off">
+                    <input type="text" name="q" class="search-input" placeholder="Search..." autofill="off" />
+                </form>
+                <span id="search-details"></span>
+            </div>
+        </section>
+        <section class="content" id="search-results"></section>
+      </div>
+    </main>
+  {% include javascript.html %}
+  {% include events-toolkit.html %}
+  {% include search.html %}
+  </body>
+</html>

--- a/assets/stylesheets/base.scss
+++ b/assets/stylesheets/base.scss
@@ -21,3 +21,4 @@ $baseurl: "{{ site.baseurl }}";
 @import "components/header";
 @import "components/sidebar";
 @import "components/toc";
+@import "components/search";

--- a/assets/stylesheets/components/_search.scss
+++ b/assets/stylesheets/components/_search.scss
@@ -1,0 +1,61 @@
+.search {
+    width: 100%;
+    padding: 0;
+    margin: 0;
+}
+
+.search input {
+    font-size: 1.2rem;
+    height: 40px;
+}
+
+.search input[type="text"] {
+    padding: 5px 10px 5px 35px;
+    width: 100%;
+    outline: none;
+    border: 1px solid #2d2e2e;
+    border-radius: 5px;
+    background: #ffffff url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='24' height='24' fill='none' viewBox='0 0 24 24'><path d='M5.134 17.452l-2.843 2.842 1.415 1.415 2.842-2.843-1.414-1.414zM13 3c-4.41 0-8 3.59-8 8 0 3.75 2.98 8 8 8 4.41 0 8-3.59 8-8s-3.59-8-8-8zm0 14c-3.8 0-6-3.21-6-6 0-3.31 2.69-6 6-6s6 2.69 6 6-2.69 6-6 6z' fill='%23a8a5a0'></path></svg>") no-repeat 6px center;
+}
+
+.search-details {
+    color: $batmobile;
+    margin-left: 10px;
+}
+
+.platform-header .search {
+    text-align: right;
+}
+
+.platform-header .search input {
+    font-size: 14px;
+}
+
+.platform-header .search input[type="text"] {
+    max-width: 200px;
+}
+
+#search-results {
+    padding-left: 10px;
+}
+
+.result {
+    margin-bottom: 30px;
+}
+
+.search-result-title {
+    margin-bottom: 5px;
+}
+
+.search-result-details {
+    padding-left: 10px;
+}
+
+.search-result-collection {
+    color: $batmobile;
+    font-weight: bold;
+}
+
+.search-result-text {
+    margin: 10px 0;
+}

--- a/assets/stylesheets/components/_search.scss
+++ b/assets/stylesheets/components/_search.scss
@@ -1,21 +1,29 @@
 .search {
-    width: 100%;
     padding: 0;
     margin: 0;
+
+    input {
+        font-size: 1.2rem;
+        height: 40px;
+    }
+    
+    input[type="text"] {
+        padding: 5px 10px 5px 35px;
+        width: 100%;
+        outline: none;
+        border: 1px solid #2d2e2e;
+        border-radius: 5px;
+        background: #ffffff url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='24' height='24' fill='none' viewBox='0 0 24 24'><path d='M5.134 17.452l-2.843 2.842 1.415 1.415 2.842-2.843-1.414-1.414zM13 3c-4.41 0-8 3.59-8 8 0 3.75 2.98 8 8 8 4.41 0 8-3.59 8-8s-3.59-8-8-8zm0 14c-3.8 0-6-3.21-6-6 0-3.31 2.69-6 6-6s6 2.69 6 6-2.69 6-6 6z' fill='%23a8a5a0'></path></svg>") no-repeat 6px center;
+    }
 }
 
-.search input {
-    font-size: 1.2rem;
-    height: 40px;
-}
-
-.search input[type="text"] {
-    padding: 5px 10px 5px 35px;
+.content .search {
     width: 100%;
-    outline: none;
-    border: 1px solid #2d2e2e;
-    border-radius: 5px;
-    background: #ffffff url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='24' height='24' fill='none' viewBox='0 0 24 24'><path d='M5.134 17.452l-2.843 2.842 1.415 1.415 2.842-2.843-1.414-1.414zM13 3c-4.41 0-8 3.59-8 8 0 3.75 2.98 8 8 8 4.41 0 8-3.59 8-8s-3.59-8-8-8zm0 14c-3.8 0-6-3.21-6-6 0-3.31 2.69-6 6-6s6 2.69 6 6-2.69 6-6 6z' fill='%23a8a5a0'></path></svg>") no-repeat 6px center;
+}
+
+.sidebar .search {
+    width: 90%;
+    margin: 0 auto 30px auto;
 }
 
 .search-details {

--- a/search.md
+++ b/search.md
@@ -1,0 +1,5 @@
+---
+layout: search
+---
+
+# Search

--- a/search/content.json
+++ b/search/content.json
@@ -1,0 +1,23 @@
+---
+layout: null
+---
+{% assign first = true %}
+[
+{% for dir in site.collections %}
+    {% assign collection = dir.label %}
+    {% for post in site[collection] %}
+        {% if post.title != null and post.title != empty %}
+        {% unless first %},{% endunless %}{
+            "title": {{post.title | jsonify}},
+            "content": {{post.content | markdownify | strip_html | jsonify}},
+            "link": "{{ site.baseurl }}{{ post.url }}",
+            "date": "{{ post.date }}",
+            "excerpt": "{{ post.snippet }}",
+            "search_omit": "{{ post.search_omit }}",
+            "collection": "{{ collection }}"
+        }
+        {% assign first = false %}
+        {% endif %}
+    {% endfor %}
+{% endfor %}
+]


### PR DESCRIPTION
As Google continues to shift its business model for its search features towards displaying ads, the Google-enhanced search bar becomes less useful. Currently, most searches include 3 to 5 ads before the actual results (requiring the user to scroll), and in some cases (such as when your search includes the word "Zapier") that includes ads for our competitors.

For example, when they search "how to build a Zapier integration", the user is presented with ads for Tray.io and MuleSoft:

![Current search results, which include ads for a competitor](https://cdn.zappy.app/93fa9b8dad0fe21d255623460ef6dcfb.png)

This update uses Jekyll's features to create a JSON file of all articles, then adds javascript to filter and sort that JSON based on the user's search query. The results are then displayed on a search page in order of relevance:

![Example of the same search as before, using an internal search page](https://cdn.zappy.app/bfbbd096a9fca1c8db420089509c468e.png)

> *Note:* Articles can also be omitted from search results by adding `search_omit: true` to their frontmatter.

Because analytics are gathered on a per-page basis, and not from the Google Search plugin, we should be able to replace it without losing any data. 

This update does limit the `?q=` URL param to just the `/search` page, so users who might have saved searches (such as with the "custom search engine" option in Google Chrome) may want to update. We could also add a redirect to `/search` whenever the `?q=` param is present, but omitting that change for now allows us more flexibility.