### PR TITLE
[SUPPORTENG-481] Updated OAuth2 Input Form section to note key limitations

### DIFF
--- a/docs/_docs/oauth.md
+++ b/docs/_docs/oauth.md
@@ -57,7 +57,7 @@ Zapier includes two types of fields: standard fields, which work much like other
 
 For input fields, select the default _Field_ type, then add:
 
-- **Key**: The internal name for your field, used to reference this field in Zapier API calls. For convenience, use the same key as your API uses for this field.
+- **Key**: The internal name for your field, used to reference this field in Zapier API calls. For convenience, use the same key as your API uses for this field. Note: `client_id` and `client_secret` are reserved and cannot be used as keys for input form fields.
 - **Label**: A human-friendly name for this field that will be shown to users in the authentication form.
 - **Required? (checkbox)**: Check if this field is required for successful authentication.
 - **Type**: (optional) Usually String, but select "Password" to obscure text for secret values.


### PR DESCRIPTION
Here, I've updated the [Key bullet point](https://platform.zapier.com/docs/oauth#add-an-oauth-input-form-optional:~:text=Key%3A%20The%20internal%20name%20for%20your%20field%2C%20used%20to%20reference%20this%20field%20in%20Zapier%20API%20calls.%20For%20convenience%2C%20use%20the%20same%20key%20as%20your%20API%20uses%20for%20this%20field.) in the "Authentication — OAuth v2" to note that `client_id` and `client_secret` cannot be used as input form keys.

In testing, documented in the Slack threads linked in the accompanying Jira ticket, it appears `client_id` in particular conflicts with the similarly named environment variable, causing issues in the token request. This can be avoided by refraining from using these key names in input form fields in the OAuth2 config.

