### PR TITLE
Add instructions for embedding domains on the Developer Platform

### DIFF
--- a/docs/_embed/security.md
+++ b/docs/_embed/security.md
@@ -15,6 +15,6 @@ Our user's security is paramount. By default, we deny any embedding of our produ
 
 To provide us a list of unique domains you'll embed Zapier in:
 
-- if you've already embedded our Product, you're in luck! We should have already captured this and have permitted your product domains. Should we have missed any, please [reach out to us](mailto:partners@zapier.com) so we can add your domain.
+- if you've already embedded our Product, you're in luck! We should have already captured this and have permitted your product domains. Should we have missed any, navigate to the Embed > Settings section of the [Developer Platform](https://developer.zapier.com/), and add the missing domains under the `Embedding Domains` tab.
 - else if you've already applied for a Partner API access: contact [partners@zapier.com](mailto:partners@zapier.com) and include the domains you'd like to register.
 - otherwise, when you [apply for the Partner API access](https://zapier.typeform.com/to/atnWuF) you'll have the opportunity to supply us the embedding domains inside of the form.


### PR DESCRIPTION
These changes update the `Embed` ➡️ `Security` page to encourage Partner's to update their domains instead of emailing `partners@zapier.com`