### PR TITLE
[UDOCS-1190] Private integrations: rate limit update docs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -31,6 +31,9 @@ collections:
   cli_tutorials:
     output: true
     permalink: /:collection/:name
+  private_integrations:
+    output: true
+    permalink: /:collection/:name       
   legacy:
     output: true
     permalink: /:collection/:name
@@ -45,7 +48,7 @@ collections:
     permalink: /:collection/:name
   conversion:
     output: true
-    permalink: /:collection/:name
+    permalink: /:collection/:name   
 
 defaults:
   - scope:
@@ -97,4 +100,10 @@ defaults:
       path: ""
       type: "embed"
     values:
+      layout: default  
+  - scope:
+      path: ""
+      type: "private_integrations"
+    values:
       layout: default
+

--- a/_includes/side-nav.html
+++ b/_includes/side-nav.html
@@ -8,14 +8,15 @@
           <input type="text" name="q" class="search-input" placeholder="Search..." autofill="off" />
       </form>
     </div>
-    {% include side-nav-item.html title="Quick Start" items=site.quickstart section_id="quickstart" current_section=current_section %}
+    {% include side-nav-item.html title="Quick start" items=site.quickstart section_id="quickstart" current_section=current_section %}
     {% include side-nav-item.html title="Documentation" items=site.docs section_id="docs" current_section=current_section %}
-    {% include side-nav-item.html title="CLI Documentation" items=site.cli_docs section_id="cli_docs" current_section=current_section %}
-    {% include side-nav-item.html title="CLI Tutorials" items=site.cli_tutorials section_id="cli_tutorials" current_section=current_section %}
-    {% include side-nav-item.html title="Legacy Web Builder" items=site.legacy section_id="legacy" current_section=current_section %}
-    {% include side-nav-item.html title="Web Builder Conversion" items=site.conversion section_id="conversion" current_section=current_section %}
+    {% include side-nav-item.html title="CLI documentation" items=site.cli_docs section_id="cli_docs" current_section=current_section %}
+    {% include side-nav-item.html title="CLI tutorials" items=site.cli_tutorials section_id="cli_tutorials" current_section=current_section %}
+    {% include side-nav-item.html title="Private integrations" items=site.private_integrations section_id="private_integrations" currect_section=current_section %}
+    {% include side-nav-item.html title="Legacy web builder" items=site.legacy section_id="legacy" current_section=current_section %}
+    {% include side-nav-item.html title="Web builder conversion" items=site.conversion section_id="conversion" current_section=current_section %}
     {% include side-nav-item.html title="Partners" items=site.partners section_id="partners" current_section=current_section %}
-    {% include side-nav-item.html title="Partner Success Stories" items=site.partner_success_stories section_id="partner_success_stories" current_section=current_section %}
+    {% include side-nav-item.html title="Partner success stories" items=site.partner_success_stories section_id="partner_success_stories" current_section=current_section %}
     {% include side-nav-item.html title="Embed" items=site.embed section_id="embed" current_section=current_section %}
   </nav>
 </div>

--- a/docs/_private_integration/private_integration_rate_limits.md
+++ b/docs/_private_integration/private_integration_rate_limits.md
@@ -1,0 +1,16 @@
+---
+title: Private integration rate limits
+order: 1
+layout: post-toc
+redirect_from: /private_integrations/
+---
+# Private integration rate limits
+
+Private integration rate limits are based on your current Zapier plan. When users use your private app in their Zaps, their Zap runs will be [held](https://help.zapier.com/hc/en-us/articles/8496291148685-View-and-manage-your-Zap-history) if they exceed the following limits:
+
+- Free, Starter, and Professional plans: 100 calls every 60 seconds.
+- Team, or Company plans: 5000 calls every 60 seconds.
+
+## Increasing private integration rate limits
+
+To increase a private integration rate limit for your users, you can [upgrade your Zapier plan](https://help.zapier.com/hc/en-us/articles/8496277302157-Change-or-cancel-your-Zapier-plan). To request an increase in the rate limit for your private integration beyond 5000 calls, contact our [Sales team](https://zapier.com/l/contact-sales).


### PR DESCRIPTION
Private integrations have increased rate limits for Team and Company plans. More details in this jira issue: https://zapierorg.atlassian.net/jira/software/c/projects/UDOCS/boards/283?modal=detail&selectedIssue=UDOCS-1190

Currently, we don't have space in the existing IA to insert this information. I've created a new category called "Private Integrations", as we have other new docs that we will be releasing shortly.

Note: the new category "Private Integrations" is a temporary solution and will be overhauled later this year as part of the work for #overhaul-platform-docs.

I've also updated the category titles to follow sentence case.