### PR TITLE
[UDOCS-1383] new docs for NLA + Zapier's ChatGPT plugin

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -49,6 +49,9 @@ collections:
   conversion:
     output: true
     permalink: /:collection/:name
+  zapier_products:
+    output: true
+    permalink: /:collection/:name
 
 defaults:
   - scope:
@@ -104,5 +107,10 @@ defaults:
   - scope:
       path: ""
       type: "private_integrations"
+    values:
+      layout: default
+  - scope:
+      path: ""
+      type: "zapier_products"
     values:
       layout: default

--- a/_includes/side-nav.html
+++ b/_includes/side-nav.html
@@ -13,10 +13,11 @@
     {% include side-nav-item.html title="CLI documentation" items=site.cli_docs section_id="cli_docs" current_section=current_section %}
     {% include side-nav-item.html title="CLI tutorials" items=site.cli_tutorials section_id="cli_tutorials" current_section=current_section %}
     {% include side-nav-item.html title="Private integrations" items=site.private_integrations section_id="private_integrations" current_section=current_section %}
-    {% include side-nav-item.html title="Legacy web builder" items=site.legacy section_id="legacy" current_section=current_section %}
-    {% include side-nav-item.html title="Web builder conversion" items=site.conversion section_id="conversion" current_section=current_section %}
+    {% include side-nav-item.html title="Zapier products" items=site.zapier_products section_id="zapier_products" current_section=current_section %}
     {% include side-nav-item.html title="Partners" items=site.partners section_id="partners" current_section=current_section %}
     {% include side-nav-item.html title="Partner success stories" items=site.partner_success_stories section_id="partner_success_stories" current_section=current_section %}
     {% include side-nav-item.html title="Embed" items=site.embed section_id="embed" current_section=current_section %}
+    {% include side-nav-item.html title="Legacy web builder" items=site.legacy section_id="legacy" current_section=current_section %}
+    {% include side-nav-item.html title="Web builder conversion" items=site.conversion section_id="conversion" current_section=current_section %}
   </nav>
 </div>

--- a/docs/_zapier_products/natural_language_actions_api.md
+++ b/docs/_zapier_products/natural_language_actions_api.md
@@ -1,0 +1,26 @@
+---
+title: Natural Language Actions API
+order: 1
+layout: post-toc
+redirect_from: /zapier_products/
+---
+
+# Natural Language Actions API
+
+Zapier’s [Natural Language Actions (NLA) API](https://nla.zapier.com/api/v1/docs) is a beta product designed to work with natural language-based products. It leverages the Zapier platform, with over [5000 apps](https://zapier.com/apps). You can include the capabilities of Zapier’s platform in your own product.
+
+With the Natural Language Actions API, you can:
+* Access Zapier’s platform of 5000+ apps within your own product.
+* Integrate with chatbots or [large language models](https://en.wikipedia.org/wiki/Wikipedia:Large_language_models).
+* Power any integration project.
+
+Learn more in our [Natural Language Actions API documentation](https://nla.zapier.com/api/v1/docs).
+
+## Get access to the Natural Language Action API
+
+Natural Language Actions API is available for any Zapier partner or developer to build on.
+
+It’s free to use by visiting our [Getting Started with Natural Language Actions page](https://nla.zapier.com/get-started/). For OAuth credentials, [sign up for access via our form](https://zapier.com/l/natural-language-actions). You’ll receive access once your application is reviewed.
+
+> **Note**: By signing up for API access, you agree to [Zapier’s Platform Agreement](https://zapier.com/platform/tos) and [Privacy Policy](https://zapier.com/privacy).
+✕

--- a/docs/_zapier_products/zapiers_chatgpt_plugin.md
+++ b/docs/_zapier_products/zapiers_chatgpt_plugin.md
@@ -1,0 +1,13 @@
+---
+title: Zapier’s ChatGPT Plugin
+order: 2
+layout: post-toc
+redirect_from: /zapier_products/
+---
+
+# Zapier’s ChatGPT Plugin
+
+The [Zapier ChatGPT Plugin](https://help.zapier.com/hc/en-us/articles/14058263394573) is a beta product that allows users to use Zapier actions directly in ChatGPT Plus. Users can perform searches and actions with any of the 5,000+ Zapier apps within ChatGPT Plus. This capability is powered by Zapier’s [Natural Language Action API](https://nla.zapier.com/api/v1/docs).
+
+> **Note**: Zapier ChatGPT Plugin only supports [beta and public Zapier integrations](https://platform.zapier.com/partners/lifecycle-planning).
+✕


### PR DESCRIPTION
This is a copy of the following PR: https://github.com/zapier/visual-builder/pull/428. That PR had a typo in ` current_selection=current_section`, and I could not modify it. As we are looking to release this soon, I figured I would just re-create the PR and get it ready to merge!

Original description:
```
Created a new category called "Zapier products".
Created two new docs:

Natural Language Actions API
Zapier's ChatGPT Plugin
Do not publish, until Laura has reached out to confirm we are ready for these new docs and category to go live in the Platform docs.
```