### PR TITLE
[PARTOPS-599] Remove typo in PKCE screenshot markdown

### DIFF
--- a/docs/_docs/oauth.md
+++ b/docs/_docs/oauth.md
@@ -91,7 +91,7 @@ If you ever need to reference Zapier's redirect URL inside your Zapier integrati
 <a id="PKCE"></a>
 ## Add PKCE Support
 
-![Zapier OAuth v2 with PKCE Extension])(https://cdn.zappy.app/124a3c00d8bc37dadd953f19451205a5.png)
+![Zapier OAuth v2 with PKCE Extension](https://cdn.zappy.app/124a3c00d8bc37dadd953f19451205a5.png)
 
 Zapier provides built-in support for [PKCE](https://oauth.net/2/pkce/#credentials) (Proof Key for Code Exchange and pronounced "pick-see"), an extension to the authorization code flow that adds a layer of protection against security vulnerabilities. The code generation and exchange steps of the flow occur automatically by Zapier when enabled.
 


### PR DESCRIPTION
This PR aims to fix this issue in the [PKCE documentation](https://platform.zapier.com/docs/oauth#add-pkce-support):
![](https://cdn.zappy.app/d563a98ab7221bf1af1038080d985564.png)