### PR TITLE
[PARTOPS-604] Add Partner API `/apps` returning `app_latest`

### DIFF
--- a/docs/_embed/partner_api.md
+++ b/docs/_embed/partner_api.md
@@ -191,7 +191,8 @@ curl -L "https://api.zapier.com/v1/apps?client_id=${client_id}&per_page=5"
         "url_32x32": "https://zapier-images.imgix.net/storage/services/6cf3f5a461feadfba7abc93c4c395b33_2.png?auto=format%2Ccompress&fit=crop&h=32&ixlib=python-3.0.0&q=50&w=32",
         "url_64x64": "https://zapier-images.imgix.net/storage/services/6cf3f5a461feadfba7abc93c4c395b33_2.png?auto=format%2Ccompress&fit=crop&h=64&ixlib=python-3.0.0&q=50&w=64",
         "url_128x128": "https://zapier-images.imgix.net/storage/services/6cf3f5a461feadfba7abc93c4c395b33_2.png?auto=format%2Ccompress&fit=crop&h=128&ixlib=python-3.0.0&q=50&w=128"
-      }
+      },
+      "app_latest": "SlackAPI"
     },
     {
       "uuid": "d74234df-0045-436e-bd5b-ee577e74e6b8",
@@ -216,7 +217,8 @@ curl -L "https://api.zapier.com/v1/apps?client_id=${client_id}&per_page=5"
         "url_32x32": "https://zapier-images.imgix.net/storage/services/62c82a7958c6c29736f17d0495b6635c.png?auto=format%2Ccompress&fit=crop&h=32&ixlib=python-3.0.0&q=50&w=32",
         "url_64x64": "https://zapier-images.imgix.net/storage/services/62c82a7958c6c29736f17d0495b6635c.png?auto=format%2Ccompress&fit=crop&h=64&ixlib=python-3.0.0&q=50&w=64",
         "url_128x128": "https://zapier-images.imgix.net/storage/services/62c82a7958c6c29736f17d0495b6635c.png?auto=format%2Ccompress&fit=crop&h=128&ixlib=python-3.0.0&q=50&w=128"
-      }
+      },
+      "app_latest": "GoogleCalendarAPI"
     }
   ],
   "prev_url": "https://api.zapier.com/v1/apps?per_page=2&page=1",
@@ -511,15 +513,16 @@ curl -H "Authorization: Bearer {token}" -L "https://api.zapier.com/v1/profiles/m
 
 | attribute       | type   | notes                                                                                                                                                 |
 | --------------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **uuid**        | String | The unique canonical identifier to the app                                                                                                             |
+| **uuid**        | String | The unique canonical identifier to the app.                                                                                                           |
 | **description** | String | Plain text description of the app.                                                                                                                    |
-| **links**       | Object | Link to get mutual Zap templates from Zapier's Partner API                                                                                            |
+| **links**       | Object | Link to get mutual Zap templates from Zapier's Partner API.                                                                                           |
 | **title**       | String | The name of the app.                                                                                                                                  |
 | **url**         | String | An absolute url to the Zapbook Apps page.                                                                                                             |
 | **image**       | String | The app's logo in large format.                                                                                                                       |
 | **images**      | Object | Thumbnails for the app image. <br><small>Available sizes (and respective keys):<br> `url_128x128`, `url_64x64`, `url_32x32`, and `url_16x16`.</small> |
 | **slug**        | String | A URL/SEO friendly ID for the app.                                                                                                                    |
 | **categories**  | Object | A list of categories this app belongs to.                                                                                                             |
+| **app_latest**  | String | An identifier for the app's production version.                                                                                                       |
 
 ```json
 {
@@ -666,6 +669,12 @@ All errors will be JSON object with a String array of errors:
 ```
 
 ## Changelog
+
+- 2023-03-30
+
+  - Added attribute to `v1/apps`
+
+    - The endpoint `/v1/apps` exposes the `app_latest` string attribute representing the SelectedAPI and production version for each app.
 
 - 2022-08-29
 

--- a/docs/_embed/zap_editor.md
+++ b/docs/_embed/zap_editor.md
@@ -42,8 +42,7 @@ URL parameters (with example values):
 Requirements:
 
 - A trigger app is required. The `steps` index for a trigger is always `0`.
-- An app is defined by `SelectedAPI@version` where SelectedAPI generally equals a titleized string of the app name + `CLIAPI` (e.g., MailchimpCLIAPI, GoogleAdsCLIAPI, FacebookLeadAdsCLIAPI). This value is case-sensitive.
-- The version for the app can be specified or set to `latest` (highly suggested) to automatically point to the current production version (e.g., MailchimpCLIAPI@latest, MailchimpCLIAPI@1.0.0).
+- Use `app_latest` values from the [`/apps` endpoint](https://platform.zapier.com/embed/partner-api#get-v1apps) of the Partner API to define an app.
 - You can define 0 to many subsequent action steps. The `steps` index for actions will be `1` or greater. Please note, only users on a paid Zapier plan have access to multi-step Zaps.
 - Events are defined by the `key` of the trigger, action, or search.
 - Field prefills are defined by the `key` of the input field. See the below [Prefill Options](https://platform.zapier.com/embed/zap-editor#prefill-options) for more details on prefilling fields.

--- a/docs/_embed/zap_editor.md
+++ b/docs/_embed/zap_editor.md
@@ -42,7 +42,7 @@ URL parameters (with example values):
 Requirements:
 
 - A trigger app is required. The `steps` index for a trigger is always `0`.
-- Use `app_latest` values from the [`/apps` endpoint](https://platform.zapier.com/embed/partner-api#get-v1apps) of the Partner API to define an app.
+- Use `app_latest` values from the [`/apps` endpoint](https://platform.zapier.com/embed/partner-api#get-v1apps) of the Partner API to define an app. This is case-sensitive, so use exactly the value returned from the API.
 - You can define 0 to many subsequent action steps. The `steps` index for actions will be `1` or greater. Please note, only users on a paid Zapier plan have access to multi-step Zaps.
 - Events are defined by the `key` of the trigger, action, or search.
 - Field prefills are defined by the `key` of the input field. See the below [Prefill Options](https://platform.zapier.com/embed/zap-editor#prefill-options) for more details on prefilling fields.


### PR DESCRIPTION
The `/apps` endpoint of the Partner API now supports returning `app_latest`, which represents the SelectedAPI and production version of an app to be used when constructing `create Zap` [prefilled editor URLs](https://platform.zapier.com/embed/zap-editor#creating-zaps-without-zap-templates).