### PR TITLE
Updating migration warning to clarify new default invite-by-email beh…

### DIFF
--- a/docs/_docs/versions.md
+++ b/docs/_docs/versions.md
@@ -118,7 +118,7 @@ In some cases, it may be more useful to migrate only a portion of the current us
 
 ![Using the Percentage slider to migrate only 55% of users](https://cdn.zappy.app/68a6701f418dbda95771258703cc609a.png)
 
-> **Warning:** Migrating a single user with the "migrate by email" option will migrate that user *and all of their team members*! If your intention is to migrate a single user, make sure to use a user account that is not in a Teams account.
+> **Warning:** By default, migrating a single user with the "migrate by email" option will only migrate Zaps that are *private to that user*—owned by the user, are not shared, and whose the integration auths are not shared.
 
 You can then repeat the Migration process later on, and migrate the rest of the users once you are comfortable with how the new version is running in production.
 


### PR DESCRIPTION
This edit clarifies the default behavior when migrating a single user by email, introduced in `12.1.0`:

https://github.com/zapier/zapier-platform/blob/main/CHANGELOG.md#1210

Previously, migrating a user by email would also migrate their teammates:

![current](https://cdn.zappy.app/1c7ee93d767550ca532fe0f4adff0da9.png)

Now, however, we only migrate Zaps that are [private to the user](https://zapier.slack.com/archives/C5Z9BP4U9/p1664502020191919?thread_ts=1664465997.430969&cid=C5Z9BP4U9). I've updated the text pictured above to clarify this behavior.

[The exception](https://github.com/zapier/zapier-platform/blob/main/packages/cli/docs/cli.md#migrate): If the dev uses the `--account` flag, we'll migrate per the old behavior pictured above.