### PR TITLE
PDE-3833 - Sanitize the search input

### DIFF
--- a/_includes/search.html
+++ b/_includes/search.html
@@ -183,12 +183,24 @@ const search = async (query) => {
     }
 }
 
+const sanitizeUserInput = (input) => {
+    /**
+    * Sanitize user input to prevent XSS attacks.
+    */
+    return input
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#039;");
+}
 /**
 * Run the search
 */
 
 if (params.q) {
-    searchInputElement.value = params.q;
-    search(params.q);
+    const query = sanitizeUserInput(params.q);
+    searchInputElement.value = query
+    search(query);
 }
 </script>


### PR DESCRIPTION
Currently the search is susceptible to XSS attacks 

This PR adds some functionality to sanitize the user input to remove any common HTML tags that may be relevant to an XSS 

Testing with this script:
`/search?q=%3Cimg%20src=x%20onerror=alert(document.cookie)%3E`

When adding the term in the search bar
![](https://cdn.zappy.app/3d49b27140461235514246fd53233ad3.png)

When adding the term in the URL bar
![](https://cdn.zappy.app/44389d05ad3deed354c01e992b2878cc.png)