### PR TITLE
[PDE-3968] Remove remaining important references + update screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Zapier Platform UI is the easiest way to build new Zapier integrations in an onl
 Zapier Platform CLI is the most advanced way to build integrations in your local development environment with your team's source code management and custom testing.
 
 - Install Zapier Platform CLI and build a sample integration in the [CLI Quick Start guide](https://zapier.com/developer/start/introduction)
-- Find detailed info on the Zapier Platform in the [Zapier Platform Schema](https://zapier.github.io/zapier-platform-schema/build/schema.html) from our built-in code docs
+- Find detailed info on the Zapier Platform in the [Zapier Platform Schema](https://github.com/zapier/zapier-platform/blob/main/packages/schema/docs/build/schema.md) from our built-in code docs
 - Start quicker with our template [Zapier CLI Example Apps](https://github.com/zapier/zapier-platform/wiki/Example-Apps)
 - Learn more in [Zapier's Platform CLI Documentation](https://platform.zapier.com/cli_docs/docs)
 

--- a/docs/_conversion/maintaining.md
+++ b/docs/_conversion/maintaining.md
@@ -106,7 +106,7 @@ When you're writing custom scripting code in the new platform the scope of that 
 
 ![](https://cdn.zappy.app/27b0a08799b047fc9db1ed204d030377.gif)
 
->Pro Tip: A handy way to understand this is to have a look at the [schema](https://zapier.github.io/zapier-platform-schema/build/schema.html) of the integration definition you're building.  [Here](https://zapier.github.io/zapier-platform-schema/build/schema.html#basicpollingoperationschema) you'll see the structure of the definition of a polling trigger.  Notice that the `perform` field takes a request configuration object, or it simply takes a Javascript function.  The new builder UI reflects this.  When you configure an API interaction, you use the form UI to configure a request, or you use "Code Mode" to write a function to be called instead.
+>Pro Tip: A handy way to understand this is to have a look at the [schema](https://github.com/zapier/zapier-platform/blob/main/packages/schema/docs/build/schema.md) of the integration definition you're building.  [Here](https://github.com/zapier/zapier-platform/blob/main/packages/schema/docs/build/schema.md#basicpollingoperationschema) you'll see the structure of the definition of a polling trigger.  Notice that the `perform` field takes a request configuration object, or it simply takes a Javascript function.  The new builder UI reflects this.  When you configure an API interaction, you use the form UI to configure a request, or you use "Code Mode" to write a function to be called instead.
 
 **No pre or post functions**
 

--- a/docs/_conversion/steps.md
+++ b/docs/_conversion/steps.md
@@ -85,7 +85,7 @@ To select the test version of your integration, click the “Version” dropdown
 
 In the left sidebar menu, select the hidden trigger or action in your integration. At the bottom of the Settings page, under “Visibility Options”, select “Shown.” Then click “Save.”
 
-![](https://cdn.zappy.app/a11912100041e9fc982d3ec9eaaabef9.png)
+![](https://cdn.zappy.app/955d4c1d7610603a676baf43eb680516.png)
 
 ### When you’re done testing
 

--- a/docs/_conversion/steps.md
+++ b/docs/_conversion/steps.md
@@ -83,7 +83,7 @@ To select the test version of your integration, click the “Version” dropdown
 
 ![](https://cdn.zappy.app/9757a3a04626669fe2836229dd7e6b86.png)
 
-In the left sidebar menu, select the hidden trigger or action in your integration. At the bottom of the Settings page click the “Visibility Options” dropdown menu and select “Important (Displayed above the fold in the Zap Editor).” Then click “Save.”
+In the left sidebar menu, select the hidden trigger or action in your integration. At the bottom of the Settings page, under “Visibility Options”, select “Shown.” Then click “Save.”
 
 ![](https://cdn.zappy.app/11786cd7941cf9eab71dc81d73f244db.png)
 

--- a/docs/_conversion/steps.md
+++ b/docs/_conversion/steps.md
@@ -85,7 +85,7 @@ To select the test version of your integration, click the “Version” dropdown
 
 In the left sidebar menu, select the hidden trigger or action in your integration. At the bottom of the Settings page, under “Visibility Options”, select “Shown.” Then click “Save.”
 
-![](https://cdn.zappy.app/11786cd7941cf9eab71dc81d73f244db.png)
+![](https://cdn.zappy.app/a11912100041e9fc982d3ec9eaaabef9.png)
 
 ### When you’re done testing
 

--- a/docs/_docs/actions.md
+++ b/docs/_docs/actions.md
@@ -124,15 +124,13 @@ Finally, in the API configuration, add your API endpoint where Zapier will by de
 
 When users use the search action in a Zap, Zapier will show your core search action settings that you set in the input designer by default. Then, if users check to create an item if nothing is found, Zapier will load the create action's input fields inside the search action so users can fill both out.
 
-## How to Reorder Actions in a Zapier Integration
+## Viewing Actions in a Zapier Integration
 
 ![Actions inside Zapier](https://cdn.zappy.app/5d3c2e8f9f6cf0f6daadd3ee97fa5e80.png)
 
-Whenever a user selects your app's integration in a Zapier action step, they'll see every create and search action in your integration. Zapier shows create actions first, followed by search actions.
+Whenever a user selects your app's integration in a Zapier action step, they'll see every create and search action in your integration. Zapier shows create actions first, followed by search actions. Actions are listed in alphabetical order.
 
-Actions are originally listed in the order you add them to your integration. As people use your integration, Zapier will show your integration's most popular actions first, automatically reordering them based on popularity.
-
-You change actions' visibility at any time, if you don't want an action to show first. Edit the action, then in the last option on the _Settings_ page, choose _Hidden_ to make this action not usable inside Zapier.
+You can change actions' visibility at any time, if you don't want an action to be shown. Open the action in the Zapier visual builder, to the _Settings_ tab, and scroll to the bottom of the page to the _Visibility Options_ section. Select _Hidden_ if you want to keep users from being able to use this action (often used if an action is deprecated but should keep working in users' existing Zaps).
 
 ## How to Remove an Existing Action
 

--- a/docs/_docs/actions.md
+++ b/docs/_docs/actions.md
@@ -23,7 +23,7 @@ Zapier strongly recommends against action steps that delete or remove data. To p
 
 ## 1. Configure Action Settings
 
-![Zapier visual builder action settings](https://cdn.zappy.app/10d48377c1b0020384db1d1029ba8fc6.png)
+![Zapier visual builder action settings](https://cdn.zappy.app/90061640a1c8e2f1f3172033c932bf57.png)
 
 To add a new action step to a Zapier integration, open the _Actions_ page in Zapier visual builder from the sidebar on the left, and select _Add Action_. Start by selecting your action type. New actions are _Create_ type by default, and will add new data to your app. If your action should lookup existing items instead, select _Search_—then jump to the [Search](#search) section below for details on setting up a search action.
 

--- a/docs/_docs/actions.md
+++ b/docs/_docs/actions.md
@@ -37,7 +37,7 @@ Then add the core details to your action, including:
 - **Name**: A human friendly plain text name for this action, typically with a verb such as _Add_ or _Create_ followed by the name of the item this action will create in your app. Shown inside the Zap editor and on Zapier's app directory marketing pages.
 - **Noun**: A single noun that describes what this action creates, used by Zapier to auto-generate text in Zaps about your action.
 - **Description**: A plain text sentence that describes what your action does to help users understand why they should use this action. Shown inside the Zap editor and on Zapier's app directory marketing pages.
-- **Visibility Options**: An option to select when this action will be shown. _Important_ is chosen by default. Choose _None_ if the action is not important, or choose _Hidden_ if this action should not be shown to users. This is helpful if you build a create action solely to pair with a search action but do not want it used on its own.
+- **Visibility Options**: An option to select when this action will be shown. _Shown_ is chosen by default. Choose _Hidden_ if this action should not be shown to users. This is helpful if you build a create action solely to pair with a search action but do not want it used on its own.
 
 Once the action settings are added, click _Save and Continue_ to add the new action and save your settings. You can edit the settings any time later with the exception of the create or search option.
 

--- a/docs/_docs/actions.md
+++ b/docs/_docs/actions.md
@@ -23,7 +23,7 @@ Zapier strongly recommends against action steps that delete or remove data. To p
 
 ## 1. Configure Action Settings
 
-![Zapier visual builder action settings](https://cdn.zappy.app/90061640a1c8e2f1f3172033c932bf57.png)
+![Zapier visual builder action settings](https://cdn.zappy.app/57f28534d180f2a642ebe0be2e236c32.png)
 
 To add a new action step to a Zapier integration, open the _Actions_ page in Zapier visual builder from the sidebar on the left, and select _Add Action_. Start by selecting your action type. New actions are _Create_ type by default, and will add new data to your app. If your action should lookup existing items instead, select _Search_—then jump to the [Search](#search) section below for details on setting up a search action.
 

--- a/docs/_docs/actions.md
+++ b/docs/_docs/actions.md
@@ -128,7 +128,7 @@ When users use the search action in a Zap, Zapier will show your core search act
 
 ![Actions inside Zapier](https://cdn.zappy.app/5d3c2e8f9f6cf0f6daadd3ee97fa5e80.png)
 
-Whenever a user selects your app's integration in a Zapier action step, they'll see every create and search action in your integration. Zapier shows create actions first, followed by search actions. Actions are listed in alphabetical order.
+Whenever a user selects your app's integration in a Zapier action step, they'll see every create and search action in your integration. Zapier shows Create actions first, followed by Search actions. Within the Create and Search sections, actions are listed in alphabetical order.
 
 You can change actions' visibility at any time, if you don't want an action to be shown. Open the action in the Zapier visual builder, to the _Settings_ tab, and scroll to the bottom of the page to the _Visibility Options_ section. Select _Hidden_ if you want to keep users from being able to use this action (often used if an action is deprecated but should keep working in users' existing Zaps).
 

--- a/docs/_docs/triggers.md
+++ b/docs/_docs/triggers.md
@@ -27,7 +27,7 @@ To create an "updated item" trigger, use an API endpoint that lists all items, b
 
 ## 1. Configure Trigger Settings
 
-![Zapier trigger settings](https://cdn.zappy.app/6af5e5288d73d9458454214318297533.png)
+![Zapier trigger settings](https://cdn.zappy.app/024547d6df8622335ca65456c6d0a11c.png)
 
 Start building your trigger by adding details about what this trigger does. You need to add both internal data to identify your trigger, and user facing text to describe the trigger to users.
 

--- a/docs/_docs/triggers.md
+++ b/docs/_docs/triggers.md
@@ -175,7 +175,7 @@ You can now make a new Zap using your trigger to test out the trigger live insid
 
 ![Triggers in Zapier](https://cdn.zappy.app/35a3f80c665bcc9afc02b2a55424b805.png)
 
-Triggers are listed in alphabetical order. You cannot set up trigger to be in a custom order in your integration's trigger list.
+Triggers are listed in alphabetical order. You cannot customize the order of your integration's trigger list.
 
 ![Trigger visibility](https://cdn.zappy.app/402a8dc91f24f70e432d03c6668fbf4e.png)
 

--- a/docs/_docs/triggers.md
+++ b/docs/_docs/triggers.md
@@ -171,15 +171,15 @@ Then click _Generate Output Field Definitions_, and Zapier will build a table of
 
 You can now make a new Zap using your trigger to test out the trigger live inside Zapier.
 
-## How to Reorder Triggers
+## Viewing Triggers in a Zapier Integration
 
 ![Triggers in Zapier](https://cdn.zappy.app/35a3f80c665bcc9afc02b2a55424b805.png)
 
-Triggers are originally listed in the order you add them to your integration. As people use your integration, Zapier will show your integration's most popular triggers first, automatically reordering them based on popularity. You cannot set a trigger to always be in a specific order in your integration's trigger list.
+Triggers are listed in alphabetical order. You cannot set up trigger to be in a custom order in your integration's trigger list.
 
-![Trigger visibility](https://cdn.zappy.app/7a059a17e929383afd61ecb4f00733c3.png)
+![Trigger visibility](https://cdn.zappy.app/402a8dc91f24f70e432d03c6668fbf4e.png)
 
-You can, however, change a trigger's visibility and thus choose whether it's shown or not at any time. Open the trigger in the Zapier visual builder, and scroll to the bottom of the page to the _Visibility Options_ menu. Select _Hidden_ if you want to keep users from being able to use this trigger (often used if the trigger is only used to power dynamic fields).
+You can, however, change a trigger's visibility and thus choose whether it's shown or not at any time. Open the trigger in the Zapier visual builder, and scroll to the bottom of the page to the _Visibility Options_ section. Select _Hidden_ if you want to keep users from being able to use this trigger (often used if the trigger is only used to power dynamic fields).
 
 ## How to Remove Triggers
 

--- a/docs/_docs/triggers.md
+++ b/docs/_docs/triggers.md
@@ -27,7 +27,7 @@ To create an "updated item" trigger, use an API endpoint that lists all items, b
 
 ## 1. Configure Trigger Settings
 
-![Zapier trigger settings](https://cdn.zappy.app/1acb400e936c56c2c021d3bc38af5790.png)
+![Zapier trigger settings](https://cdn.zappy.app/6af5e5288d73d9458454214318297533.png)
 
 Start building your trigger by adding details about what this trigger does. You need to add both internal data to identify your trigger, and user facing text to describe the trigger to users.
 

--- a/docs/_docs/triggers.md
+++ b/docs/_docs/triggers.md
@@ -37,7 +37,7 @@ Add each of the following to your trigger:
 - **Name**: A human-friendly plain-text name for this trigger, typically with an adjective such as _New_ or _Updated_ followed by the name of the item this watches for in your app. Shown inside the Zap editor and on Zapier's app directory marketing pages.
 - **Noun**: A single noun that describes what this trigger watches for, used by Zapier to auto-generate text in Zaps about your trigger.
 - **Description**: A plain text sentence that describes what the trigger does and when it should be used. Shown inside the Zap editor and on Zapier's app directory marketing pages.
-- **Visibility Options**: An option to select when this trigger will be shown. _Important_ is chosen by default. Choose _None_ if the trigger is not important, or choose _Hidden_ if this trigger should not be shown to users.
+- **Visibility Options**: An option to select when this trigger will be shown. _Shown_ is chosen by default. Choose _Hidden_ if this trigger should not be shown to users.
 
 Once the settings are added, click _Save and Continue_ to add the new trigger and save your settings. You can edit the settings any time later with the exception of the create or search option.
 

--- a/docs/_legacy/docs.md
+++ b/docs/_legacy/docs.md
@@ -993,12 +993,6 @@ Demo: <br/> _the user will see **Name** and **Help Text** like below:_
 
 ![label and help](https://cdn.zapier.com/storage/photos/d4fd7c63b1f2fe58946a4184a4bce722.png)
 
-### Important
-
-Occasionally, you'll have unimportant triggers which are used mostly to drive things like [dynamic dropdown](#dynamic-dropdowns), but could be useful to a small subset of users. If you mark a trigger as unimportant, we will hide the trigger behind a link. The user can still pick these if they really want to but it is hidden by default.
-
-> Note: if you have no important triggers, we will not hide any of them by default.
-
 ### Hide
 
 If you create a trigger solely to be used in a [dynamic dropdown](#dynamic-dropdowns) and it will never be helpful to users, you can mark it as hidden. We will never show the trigger in the UI and users will not be able to pick it.
@@ -1373,10 +1367,6 @@ This allows you to dynamically define action fields that are user set (IE: custo
 Example: <br/> {% raw %}`http://api.example.com/v2/fields.json` or `http://{% templatetag openvariable %}account{% templatetag closevariable %}.example.com/api/v1/fields.json`{% endraw %}
 
 > Read more about [custom field formatting here](#action-fields-custom).
-
-### Important
-
-Usually you'll want to leave this checked, but if you don't we'll hide that action behind an "uncommon" link when a user selects their action. Mainly this is helpful for removing actions that are there for breadth but are rarely used.
 
 ### Hide
 
@@ -1792,7 +1782,6 @@ If your action **returns** custom fields you'll also want to configure a source 
         "type": "unicode",
         "key": "json_key", // the field "name", will be used to construct a label if none is provided
         "label": "Pretty Label",
-        "important": true // optional
     },
     ...
 ]
@@ -1882,10 +1871,6 @@ Example: <br/> `find_contact`, or `findContact`
 A longer description of what this Search actually looks for. Point out any un-standard behavior as far as how searching happens.
 
 Example: <br/> `Finds a contact by email address.`
-
-### Important
-
-Usually you'll want to leave this checked, but if you don't we'll hide that search behind an "uncommon" link when a user selects their action. Mainly this is helpful for removing searches that are there for breadth but are rarely used.
 
 ### Hide
 
@@ -2095,7 +2080,6 @@ If your search action **returns** custom fields you'll also want to configure a 
         "type": "unicode",
         "key": "json_key", // the field "name", will be used to construct a label if none is provided
         "label": "Pretty Label",
-        "important": true // optional
     },
     ...
 ]

--- a/docs/_legacy/scripting.md
+++ b/docs/_legacy/scripting.md
@@ -1151,8 +1151,7 @@ bundle.response.content: <str>
                # `type` can be unicode, int, bool
                # `key` should be unique, and will be the "key" in "key: value" in the response content
                # `label` should be provided
-               # `important` is optional
-               {'type': <str>, 'key': <str>, 'label': <str>, 'important': <str>}
+               {'type': <str>, 'key': <str>, 'label': <str>}
            ]
         */
         return []; // return fields in the order you want them displayed in the UI. They'll be appended after the regular search fields
@@ -1229,8 +1228,7 @@ bundle.response.content: <str>
                # `type` can be unicode, int, bool
                # `key` should be unique, and will be the "key" in "key: value" in the response content
                # `label` should be provided
-               # `important` is optional
-               {'type': <str>, 'key': <str>, 'label': <str>, 'important': <str>}
+               {'type': <str>, 'key': <str>, 'label': <str>}
            ]
     */
         return []; // return fields in the order you want them displayed in the UI. They'll be appended after the regular search fields

--- a/docs/_partners/common-migration-errors.md
+++ b/docs/_partners/common-migration-errors.md
@@ -25,7 +25,7 @@ The Triggers, Actions, and Searches are identified by their **key**, such as `ne
 
 There are two solutions:
 
-- If you need to remove a Trigger/Action/Search, change its visibility to **hidden** instead. Use the Visibility Options dropdown in the [UI](https://platform.zapier.com/docs/triggers#1-configure-trigger-settings), or the `hidden` key in the [CLI](https://zapier.github.io/zapier-platform-schema/build/schema.html#basicdisplayschema).
+- If you need to remove a Trigger/Action/Search, change its visibility to **hidden** instead. Use the Visibility Options dropdown in the [UI](https://platform.zapier.com/docs/triggers#1-configure-trigger-settings), or the `hidden` key in the [CLI](https://github.com/zapier/zapier-platform/blob/main/packages/schema/docs/build/schema.md#basicdisplayschema).
 - If you've renamed the **key** for a Trigger/Action/Search, you'll need to switch it back to the previous **key**.
 
 ### You cannot change the authentication type

--- a/docs/_partners/integration-review-guidelines.md
+++ b/docs/_partners/integration-review-guidelines.md
@@ -182,7 +182,7 @@ Additionally, each trigger must have:
 #### 4.2.4 Field Types
 * Use the most appropriate [input field type](https://platform.zapier.com/docs/input-designer#zapier-input-field-types) for each of the input fields to show users what type of data to include — though do note the Zap Editor does not validate the data to ensure users added the correct item for that field type. 
 
-* If the field can accept multiple values, use our built in [‘List’ property](https://zapier.github.io/zapier-platform-schema/build/schema.html#fieldschema) or ‘[Allow Multiples’](https://platform.zapier.com/docs/input-designer#allows-multiples) functionality rather than asking users to provide a comma-separated value in a text field.
+* If the field can accept multiple values, use our built in [‘List’ property](https://github.com/zapier/zapier-platform/blob/main/packages/schema/docs/build/schema.md#fieldschema) or ‘[Allow Multiples’](https://platform.zapier.com/docs/input-designer#allows-multiples) functionality rather than asking users to provide a comma-separated value in a text field.
 
 #### 4.2.5 Ordering
 * Put required trigger input fields at the top of the form with optional fields towards the bottom by importance.
@@ -281,7 +281,7 @@ All action steps *must* include [input fields](https://platform.zapier.com/docs/
 * Order action fields logically. If you are unsure, look at how the respective fields are ordered in your platform and mimic that since users will be familiar with that ordering. 
 * Required action fields should generally be listed first at the top of the Zap Editor.
 * Place all optional, lesser-used fields towards the bottom.
-* Group related fields together. For example, first name and last name fields, as well as individual address component fields should be ordered consecutively. Do NOT use [line-item groups](https://platform.zapier.com/docs/input-designer#how-to-add-a-line-item-group) or the [‘children’](https://zapier.github.io/zapier-platform-schema/build/schema.html#fieldschema) field schema key to visually group fields; these are solely intended for line-item functionality.
+* Group related fields together. For example, first name and last name fields, as well as individual address component fields should be ordered consecutively. Do NOT use [line-item groups](https://platform.zapier.com/docs/input-designer#how-to-add-a-line-item-group) or the [‘children’](https://github.com/zapier/zapier-platform/blob/main/packages/schema/docs/build/schema.md#fieldschema) field schema key to visually group fields; these are solely intended for line-item functionality.
 
 #### 5.2.3 Required Fields
 * If a field doesn't have to be required, don't make it! Parallel the required fields from your integration as closely as possible. For example, if 'Email Address' is not required to create a lead in the platform, do not make the 'Email Address' field required in the Zapier editor. If the API specifies a non-important field as required, hard-code a default value so the field is not empty if one is not provided by the user.
@@ -299,7 +299,7 @@ All action steps *must* include [input fields](https://platform.zapier.com/docs/
 #### 5.2.6 Field Types
 * Use the most appropriate [input field type](https://platform.zapier.com/docs/input-designer#zapier-input-field-types) for each of the input fields to show users what type of data to include — though do note Zapier does not validate the data to ensure users added the correct item for that field type.
 
-* If the field can accept multiple values, use our built in [‘List’ property](https://zapier.github.io/zapier-platform-schema/build/schema.html#fieldschema) or ‘[Allow Multiples’](https://platform.zapier.com/docs/input-designer#allows-multiples) functionality rather than asking users to provide a comma-separated value in a text field.
+* If the field can accept multiple values, use our built in [‘List’ property](https://github.com/zapier/zapier-platform/blob/main/packages/schema/docs/build/schema.md#fieldschema) or ‘[Allow Multiples’](https://platform.zapier.com/docs/input-designer#allows-multiples) functionality rather than asking users to provide a comma-separated value in a text field.
 
 ### 5.3 [Response Content](https://zapier.com/developer/documentation/v2/integration-dev-guide/#action-response-content)
 Return information about the resource that was created, updated, or affected by the action, and not just a 'success' message. At a minimum, return an ID, the name or title of the resource (when pertinent), and a link to the newly created, updated, or affected resource in the platform (if available). Additionally, return any other useful data about the resource users may need in subsequent actions of a multi-step Zap.
@@ -378,7 +378,7 @@ Additionally, each search must have:
 
 #### 6.3.4 Field Types
 * Use the most appropriate [input field type](https://platform.zapier.com/docs/input-designer#zapier-input-field-types) for each of the input fields to show users what type of data to include — though do note Zapier does not validate the data to ensure users added the correct item for that field type. 
-* If the field can accept multiple values, use our built in [‘List’ property](https://zapier.github.io/zapier-platform-schema/build/schema.html#fieldschema) or ‘[Allow Multiples’](https://platform.zapier.com/docs/input-designer#allows-multiples) functionality rather than asking users to provide a comma-separated value in a text field.
+* If the field can accept multiple values, use our built in [‘List’ property](https://github.com/zapier/zapier-platform/blob/main/packages/schema/docs/build/schema.md#fieldschema) or ‘[Allow Multiples’](https://platform.zapier.com/docs/input-designer#allows-multiples) functionality rather than asking users to provide a comma-separated value in a text field.
 
 #### 6.3.5 Ordering
 * Put required search fields at the top of the form with optional fields towards the bottom by importance.

--- a/docs/_partners/planning-guide.md
+++ b/docs/_partners/planning-guide.md
@@ -142,7 +142,7 @@ Every Zapier integration includes at least one trigger or action, and ideally wi
 
 Follow the following guidelines whenever creating a trigger, create action, or search action:
 
-**Include at least 3 important triggers, actions, and searches at launch** Think through the use cases where users would use your Zapier integration, and try to build Zap steps that fit those needs. You can add additional Zap steps later based on user feedback. Triggers and actions are most important; searches could be added later as advanced features.
+**Include at least 3 triggers, actions, and searches at launch** Think through the use cases where users would use your Zapier integration, and try to build Zap steps that fit those needs. You can add additional Zap steps later based on user feedback. Triggers and actions are most important; searches could be added later as advanced features.
 
 **Use a descriptive name**. Each trigger, action, and search must include a name in title case, along with a simple description of what that step does. Start with the phrase "Triggers when", "Creates a new", or "Finds a" for triggers, create actions, and search actions, respectively, followed by three to five words additional words.
 

--- a/index.md
+++ b/index.md
@@ -18,7 +18,7 @@ Zapier Platform UI is the easiest way to build new Zapier integrations in an onl
 Zapier Platform CLI is the most advanced way to build integrations in your local development environment with your team's source code management and custom testing.
 
 - Install Zapier Platform CLI and build a sample integration in the [CLI Quick Start guide](https://zapier.com/developer/start/introduction)
-- Find detailed info on the Zapier Platform in the [Zapier Platform Schema](https://zapier.github.io/zapier-platform-schema/build/schema.html) from our built-in code docs
+- Find detailed info on the Zapier Platform in the [Zapier Platform Schema](https://github.com/zapier/zapier-platform/blob/main/packages/schema/docs/build/schema.md) from our built-in code docs
 - Start quicker with our template [Zapier CLI Example Apps](https://github.com/zapier/zapier-platform/wiki/Example-Apps)
 - Learn more in [Zapier's Platform CLI Documentation](https://platform.zapier.com/cli_docs/docs)
 


### PR DESCRIPTION
We're removing the `important` field per [this epic](https://zapierorg.atlassian.net/browse/PDE-3962). 

References to that field and screenshots showing the deprecated selection dropdown need to be removed from the docs or updated.

We also realized that there are quite a few references to the outdated `schema.html` on Github pages -- therefore this PR also replaces links to those with links to `https://github.com/zapier/zapier-platform/blob/main/packages/schema/docs/build/schema.md`.