### PR TITLE
[PDE-3968] Updating leftover screenshots for Actions and Triggers with new designs

### DIFF
--- a/docs/_docs/actions.md
+++ b/docs/_docs/actions.md
@@ -7,11 +7,11 @@ redirect_from: /docs/
 
 # Actions
 
-![Zapier Action Visual Builder](https://cdn.zappy.app/8b5a6ba27686f0aa783c97949da0dee3.png)
+![Zapier Action Visual Builder](https://cdn.zappy.app/57f28534d180f2a642ebe0be2e236c32.png)
 
 All Zaps start with a trigger that watches for new or updated data. They get the ball rolling. Everything a Zap does with that data, though, is done by actions.
 
-Zapier actions push or put new data into apps through API calls that pass data from user customized [input fields](https://platform.zapier.com/docs/input-designer). 
+Zapier actions push or put new data into apps through API calls that pass data from user customized [input fields](https://platform.zapier.com/docs/input-designer).
 
 Action steps in Zaps can create new items in an app or update existing items with a *create* action, or find existing items in an app with *search* actions. Search actions can optionally be paired with create actions to add a new item if the search does not return a result.
 
@@ -23,7 +23,7 @@ Zapier strongly recommends against action steps that delete or remove data. To p
 
 ## 1. Configure Action Settings
 
-![Zapier visual builder action settings](https://cdn.zappy.app/57f28534d180f2a642ebe0be2e236c32.png)
+![Zapier visual builder action settings](https://cdn.zappy.app/c845778e65b58839d1fac151d805bb55.png)
 
 To add a new action step to a Zapier integration, open the _Actions_ page in Zapier visual builder from the sidebar on the left, and select _Add Action_. Start by selecting your action type. New actions are _Create_ type by default, and will add new data to your app. If your action should lookup existing items instead, select _Search_—then jump to the [Search](#search) section below for details on setting up a search action.
 
@@ -106,7 +106,7 @@ To use custom code, click the _Switch to Code Mode_ button. Zapier will translat
 <a id="search"></a>
 ## How to Add a Search Action
 
-![Zapier Search action settings](https://cdn.zappy.app/8aa8bbe51aae1dc502ca46ef0a00396b.png)
+![Zapier Search action settings](https://cdn.zappy.app/3e47ad8a26c30fb761fdd60390d8705e.png)
 
 Building a search action is much the same as building a create action, only with a couple extra steps. Select *Search* as your action type, then fill in the core action settings as normal.
 

--- a/docs/_docs/triggers.md
+++ b/docs/_docs/triggers.md
@@ -7,7 +7,7 @@ redirect_from: /docs/
 
 # Triggers
 
-![Zapier Trigger Visual Builder](https://cdn.zappy.app/241f7b2bd64067f8e555d37777469d80.png)
+![Zapier Trigger Visual Builder](https://cdn.zappy.app/024547d6df8622335ca65456c6d0a11c.png)
 
 Every Zap starts with one trigger, powered by either a webhook subscription that watches for new data as it comes in, or a polling API call to check for new data periodically.
 
@@ -27,7 +27,7 @@ To create an "updated item" trigger, use an API endpoint that lists all items, b
 
 ## 1. Configure Trigger Settings
 
-![Zapier trigger settings](https://cdn.zappy.app/024547d6df8622335ca65456c6d0a11c.png)
+![Zapier trigger settings](https://cdn.zappy.app/2ec8af054d697bc5db5d21112d57ebe6.png)
 
 Start building your trigger by adding details about what this trigger does. You need to add both internal data to identify your trigger, and user facing text to describe the trigger to users.
 


### PR DESCRIPTION
In https://github.com/zapier/visual-builder/pull/445, the screenshots for the Triggers and Actions pages were updated to reflect the updated designs (see [here](https://github.com/zapier/visual-builder/pull/445/files#diff-73e571120efdacc1bda24cdf566fab608a1b5491f41ec73e1421756c3debb2b9R26) for Actions and [here](https://github.com/zapier/visual-builder/pull/445/files#diff-81d5711918d87cb8764e32d9af78805821fcb334be9259de469281f4670c7e15R30) for Triggers). But looking at the first screenshots in the [triggers docs](https://platform.zapier.com/docs/triggers) and [actions docs](https://platform.zapier.com/docs/actions), they are still using the older designs with the "important" visibility option. I believe the replacement screenshots probably were meant to replace these "heading" screenshots since they are a lot alike! So I went ahead and moved those up, meaning we needed new screenshots for the "settings" sections.

Changes in this PR:
* Moved the replacement screenshots up into the "heading".
* Added new screenshots for the "settings" section while trying to simulate the existing screenshots on the page (using an integration named the same) in order to maintain consistency!
* Also spotted a leftover screenshot related to "search" style Actions, also updated!

New screenshots for the settings sections (they have a more "full page" feel):
![Screen Shot 2023-05-23 at 9 41 29 AM](https://github.com/zapier/visual-builder/assets/4153103/d8ea01b8-2cce-462a-bff6-a6968fa7376d)

![Screen Shot 2023-05-23 at 9 42 24 AM](https://github.com/zapier/visual-builder/assets/4153103/721b7fc2-7767-4a56-8b61-1ff47c88d954)

New screenshot for the "search" style action (had a difficult time taking this full-sized screenshot...)

![Screen Shot 2023-05-23 at 10 02 30 AM](https://github.com/zapier/visual-builder/assets/4153103/e2194c17-228a-455e-ae53-b54146ccbb9d)

