### PR TITLE
[UDOCS-1654] Updates to Partner section - 90 days beta phase

### DIFF
--- a/docs/_partners/common-migration-errors.md
+++ b/docs/_partners/common-migration-errors.md
@@ -1,12 +1,12 @@
 ---
-title: Common Errors When Migrating Users
-order: 11
+title: Common errors when migrating users
+order: 10
 layout: post-toc
 redirect_from: /partners/
 ---
 <a id="deploy-errors"></a>
 
-## Common Errors When Migrating Users and Zaps Between Versions
+## Common errors when migrating users and Zaps between versions
 
 There are certain changes to an integration the platform considers breaking changes, meaning migrating users and their Zaps to the new version will break existing, live Zaps and cause them to be turned off. 
 
@@ -16,17 +16,17 @@ Here are some commonly encountered errors and breaking changes to watch out for,
 
 > **Note:** You can also always choose to promote an incompatible version, not migrate users, and either follow our [deprecation process](https://platform.zapier.com/cli_tutorials/versions#deprecate-an-older-version-of-your-integration) or leave them on the old version.
 
-### You cannot remove or update keys for existing Triggers, Actions, and Searches.
+### You cannot remove or update keys for existing triggers, actions, and searches
 
 You will see a similar error to the one below from our automated checks:
 `vX.X is missing the following keys: {<list of missing keys>}. Hide them instead of removing them.`
 
-The Triggers, Actions, and Searches are identified by their **key**, such as `new_contact` or `create_post`, so if you remove it, or change its **key**, this message appears.
+The triggers, actions, and searches are identified by their **key**, such as `new_contact` or `create_post`, so if you remove it, or change its **key**, this message appears.
 
 There are two solutions:
 
-- If you need to remove a Trigger/Action/Search, change its visibility to **hidden** instead. Use the Visibility Options dropdown in the [UI](https://platform.zapier.com/docs/triggers#1-configure-trigger-settings), or the `hidden` key in the [CLI](https://zapier.github.io/zapier-platform-schema/build/schema.html#basicdisplayschema).
-- If you've renamed the **key** for a Trigger/Action/Search, you'll need to switch it back to the previous **key**.
+- If you need to remove a trigger/action/search, change its visibility to **hidden** instead. Use the Visibility Options dropdown in the [UI](https://platform.zapier.com/docs/triggers#1-configure-trigger-settings), or the `hidden` key in the [CLI](https://zapier.github.io/zapier-platform-schema/build/schema.html#basicdisplayschema).
+- If you've renamed the **key** for a trigger/action/search, you'll need to switch it back to the previous **key**.
 
 ### You cannot change the authentication type
 
@@ -39,10 +39,10 @@ Changing an integration's authentication type (such as Basic Auth, API Key, or O
 
 If you're adding a new **required** input field or making a previously optional input field now required, it's possible Zaps without a value for the newly required field exist and thus, may break. There is no automated check for this.
 
-**If this is a field in a Trigger, Action, or Search, there are two solutions:**
+**If this is a field in a trigger, action, or search, there are two solutions:**
 
 - Leave the field as "optional", and use custom code in your API call to set a value if users leave it blank in their Zaps.
-- Copy the Trigger/Action/Search and give it a new **key** (such as appending `_v2` to the end), add your required field to the **new** Trigger/Action/Search, and **hide** the previous Trigger/Action/Search. That way, existing Zaps will continue to work with the previous (and now hidden) Trigger/Action/Search definition, and new Zaps will be forced to provide a value for the required field.
+- Copy the trigger/action/search and give it a new **key** (such as appending `_v2` to the end), add your required field to the **new** trigger/action/search, and **hide** the previous trigger/action/search. That way, existing Zaps will continue to work with the previous (and now hidden) trigger/action/search definition, and new Zaps will be forced to provide a value for the required field.
 
 **If this is a field in your authentication:**
 
@@ -51,12 +51,12 @@ This is a pretty big change, because it means all of the accounts already setup 
 There are two solutions:
 
 - Leave the field as "optional", and use custom code in your API call to set a value if left blank.
-- [Contact us](https://developer.zapier.com/contact), and we'll try to help find the best approach.
+- [Contact us](https://developer.zapier.com/contact), and we'll try to find the best approach.
 
-### You cannot change an existing Trigger's type (Polling vs REST Hooks).
+### You cannot change an existing trigger's type (Polling vs REST Hooks).
 
 A change in an existing trigger's type will cause your user's Zaps to stop working. There is no automated check for this.
 
 Here's a solution:
 
-- Copy the Trigger and give it a new **key** (such as appending `_v2` on the end), change the type for this new Trigger, and **hide** the previous Trigger. This way existing Zaps continue to work with the previous (and now hidden) Trigger definition, and new Zaps will use the new Trigger definition.
+- Copy the trigger and give it a new **key** (such as appending `_v2` on the end), change the type for this new rrigger, and **hide** the previous trigger. This way existing Zaps continue to work with the previous (and now hidden) rrigger definition, and new Zaps will use the new trigger definition.

--- a/docs/_partners/developer-platform-help.md
+++ b/docs/_partners/developer-platform-help.md
@@ -1,0 +1,46 @@
+---
+title: Get help with the Developer Platform
+order: 14
+layout: post-toc
+redirect_from: /partners/
+---
+
+# Get help with the Developer Platform
+
+You can get help with building your integration through 4 channels:
+
+## Platform and Partner Support
+
+Partnerships at Zapier has 2 incredible support teams to help answers your questions. 
+
+Need Developer assistance? Our Platform Support team offers developer support to your most common questions about:
+
+* maintaining integrations and launching new versions
+* setting up triggers and actions
+* handling errors
+* troubleshooting
+* and more!
+
+Connect with our Partner Support team! Helping you answer your most common questions about:
+
+* launching an integration
+* the Partner Program (including redeeming perks)
+* updating your integration’s branding and directory page
+* Zap templates and other embedding solutions
+* and more!
+
+To reach out to either our Platform and Partner Support teams via the [contact form](https://developer.zapier.com/contact).
+
+## Zapier’s Developer Community
+
+Zapier’s Platform team has a [community](https://community.zapier.com/developer-discussion-13) dedicated to helping developers with new and existing integrations. We’re a worldwide team, so there’s usually someone around to answer your questions. We’d love to hear about your experience building on Zapier.
+
+## Zapier Support
+
+If you have issues with a Zap or your Zapier account, reach out to Zapier Support via the [contact form](https://zapier.com/app/contact-us). This lets the support team access technical information in your account to troubleshoot your problem. You’ll receive an email response from a member of the support team regarding your issue.
+
+## Zapier Help Center
+
+[Zapier’s Help Center](https://zapier.com/help) has articles that explain how Zapier works, provide information about the apps you use on Zapier, and offer solutions for common issues that you may run into.
+
+

--- a/docs/_partners/faq.md
+++ b/docs/_partners/faq.md
@@ -1,39 +1,39 @@
 ---
-title: Zapier Integration Tips and FAQs
+title: Zapier integration tips
 order: 6
 layout: post-toc
 redirect_from: /partners/
 ---
 
-# Zapier Integration Partner Tips and FAQs
+# Zapier integration tips
 
 Before developing your Zapier integration, it’s important to be familiar with the criteria Zapier uses to review all new integrations. Follow our [Integration Branding and Design Guidelines](https://platform.zapier.com/partners/planning-guide) when building your integration.
 
 The following tips are based on the most common issues we encounter and will help you successfully launch your integration. Check out [Common Migration Errors](/partners/common-migration-errors) for tips if you're ready to deploy a new version of your integration.
 
-## Get Familiar with Zapier
+## Get familiar with Zapier
 
 If you haven't used Zapier before, [sign up](https://zapier.com/sign-up/) for a free account and try a few popular integrations before building your own. This helps you understand how Zapier works, how your users will set up Zaps, and how your integration can best fit into Zap workflows.
 
-## Focus on Key Use Cases
+## Focus on key use cases
 
 Your initial Triggers, Actions, and Searches should cover the main functionality users perform on your platform to maximize utility. Check similar integrations in [Zapier's App Directory](https://zapier.com/apps/) to get ideas on which items to include in your integration. Consistently monitor feature requests from users to fill in any gaps in functionality.
 
-## Test Early With Real Users
+## Test early with real users
 
 Hopefully, you have a bunch of keen users waiting to get their hands on your Zapier integration; don't be afraid to reach out to them for early testing. Active usage gives us confidence your integration is useable and functionally valuable for numerous users. Make sure to test the integration early and often in the Zap Editor yourself!
 
-## Maintain Consistency in Your Integration Style
+## Maintain consistency in your integration style
 
 Users should be familiar with the terminology used in your Zapier integration. The input and output field labels, and trigger/action/search names must be consistent with the terminology used in your platform's own UI. It should also be consistent with the style used in other popular Zapier integrations.
 
 We strive to give users a consistent experience throughout Zapier. Be sure to follow [Zapier's standards for app branding](https://platform.zapier.com/partners/planning-guide#how-to-brand-your-zapier-integration) so your integration fits well into the Zapier ecosystem.
 
-## Make Connecting New Accounts Easy
+## Make connecting new accounts easy
 
 Connecting to Zapier must be easy for the user. OAuth v2 is the preferred authentication scheme; otherwise, users must be able to easily retrieve or generate an API Key or other credentials themselves without needing support. Both authentication and test authentication requests should return actionable, user-friendly error messages to guide users in successfully connecting their accounts.
 
-## Ensure Your Integration is Complete and Platform Consistent
+## Ensure your integration is complete and platform consistent
 
 Only submit your integration for review when it is complete and ready to be published. Make sure to thoroughly test your integration for edge cases, fix all bugs, and address [integration checks](https://platform.zapier.com/docs/integration-checks-reference) before submitting. Confirm your integration adheres to our [Integration Review Guidelines](https://platform.zapier.com/partners/integration-review-guidelines) thoroughly. Please ensure both your platform and integration work consistently without errors.
 
@@ -41,55 +41,23 @@ Only submit your integration for review when it is complete and ready to be publ
 
 Use Zapier Issue Manager to sync and manage issues for your Zapier integration from your own issue-tracking tools (such as Jira or Trello). [Learn more and request access to Zapier Issue Manager here.](https://platform.zapier.com/partners/zim)
 
-## Provide a Valid Test Account
+## Provide a valid test account
 
 When submitting your integration for review, we require a valid, non-expiring test account under `integration-testing@zapier.com`. During the review and going forward after launch, our team may need occasional access for troubleshooting support issues. Please ensure the account is not under a trial and all necessary paid/premium features are unlocked.
 
-## Avoid Misleading or Malicious Functionality
+## Avoid misleading or malicious functionality
 
 Your integration must perform as advertised and must not give users a false impression. If it appears to promise certain features and functionalities, it needs to deliver. Do not create a Zapier integration that can be used to spam, phish, or send unsolicited messages to users.
 
 Violations of the review process or guidelines can have your integration removed from Zapier, and you could be banned from submitting more in the future.
 
-## Add Collaborators to your team
+## Add collaborators to your team
 
 Bring your team onboard by inviting other team members to your integration as Collaborators. Collaborators can log into your Zapier dashboard and gain valuable insights into your integration—including what your customers are saying about it. They can view performance data, see feature requests and bugs, and access tools to embed Zapier integrations inside your UI to rack up user adoption. 
 
----
+### Find a Zapier integration partner
 
-## Contact Zapier
-
-Can't find the answer you need here or in Zapier's [integration planning guide](https://platform.zapier.com/partners/planning-guide)? Feel free to get in touch with our team:
-
-### Join Zapier's Developer Community
-
-Zapier's Platform team has a [community](https://community.zapier.com/developer-discussion-13) dedicated to helping developers with new and existing integrations. We're a worldwide team, so there's usually someone around to answer your questions. We'd love to hear about your experience building on Zapier.
-
-### Contact Zapier's Platform and Partner Support Teams
-
-Partnerships at Zapier has 2 incredible support teams to help answers your questions. Have questions? [Get in touch!](https://developer.zapier.com/contact)
-
-Need Developer assistance? Our Platform Support team offers developer support to your most common questions about:
-
-- maintaining integrations and launching new versions
-- setting up triggers and actions
-- handling errors
-- troubleshooting
-- and more!
-
-Connect with our Partner Support team! Helping you answer your most common questions about:
-
-- launching an integration (and moving out of beta)
-- the Partner Program (including redeeming perks)
-- updating your integration's branding
-- Zap templates
-- and more!
-
-If you have issues with Zaps or your Zapier account, please reach out to [our customer support team](https://zapier.com/app/get-help). Our customer support team is best equipped with the most recent logs and other details to assist you.
-
-### Find a Zapier Integration Partner
-
-We're excited to help you with your Zapier integration, but we can't build it for you. If you're looking for someone to take over the technical reins, check our list of [Zapier Trusted App Developers
+We're excited to help you with your Zapier integration, but we can't build it for you. If you're looking for someone to take over the technical reins, check our list of [Zapier trusted app developers
 ](/partners/trusted-developers) to find someone who can help develop a Zapier integration for you.
 
 ### Our pledge to Zapier Platform partners

--- a/docs/_partners/feature-requests-bugs.md
+++ b/docs/_partners/feature-requests-bugs.md
@@ -1,11 +1,11 @@
 ---
-title: How to Maintain a Zapier Integration
-order: 3
+title: How to maintain a Zapier integration
+order: 9
 layout: post-toc
 redirect_from: /partners/
 ---
 
-# How to Maintain a Zapier Integration
+# How to maintain a Zapier integration
 
 Things change. Over time, you'll add new tools to your app, improve existing features, fix bugs, and continuously improve it. New features may grow it into a larger category, or make it more focused on a smaller niche. Its description will likely change, as may its logo or even name. The API may even change as your app matures.
 
@@ -13,7 +13,7 @@ Your Zapier integration needs to change, too. The best integrations are improved
 
 Keep these guidelines in mind as you maintain your Zapier integration:
 
-## How to Update App Branding in Zapier
+## How to update app branding in Zapier
 
 ![Update Zapier integration details](https://cdn.zappy.app/21501f70d3d15a341e6dc7ea90690ee6.png)
 
@@ -25,7 +25,7 @@ If your app is public, you'll then need to [send us a request](mailto:partners@z
 
 Please make sure to follow [Zapier's branding guidelines](https://platform.zapier.com/partners/planning-guide) whenever updating app branding.
 
-## How to Monitor Feature Requests and Bugs
+## How to monitor feature requests and bugs
 
 ![Issues in Zapier Integration](https://cdn.zappy.app/b986eef73a1558ee3e121cf5d985339a.png)
 
@@ -39,7 +39,7 @@ Whenever a new issue is added or updated, Zapier will log it in the _Bugs & Feat
 
 Issue notifications are automatically sent to all confirmed Administrators and Collaborators on the integration team. If an Administrator or Collaborator is listed as `Invitation Pending`, they will need to accept the invite before they start to receive issue notifications.
 
-## How to Monitor Integration Insights
+## How to monitor integration insights
 
 As you launch and maintain your integration, you should monitor and review the insights in the dashboard on a regular cadence. Insights include important data on both the integration's growth and usage, such as monthly active users, retention rates, and Zap usage by triggers and actions. You can [see all the metrics tracked](https://platform.zapier.com/partners/integration-quality#integration-insights-definitions) in this table, or access them for any integration you are an Admin or Collaborator on from the "Dashboard" tab of the developer platform.
 
@@ -47,11 +47,11 @@ As you launch and maintain your integration, you should monitor and review the i
 
 You can filter most growth metrics by the last X number of days to identify trends and changes in user activity in correlation to marketing initiatives, integration changes, and product updates like [embedding Zapier](https://platform.zapier.com/embed/full-zapier-experience). Usage details for each trigger and action will show which functionalities are the most popular and being effectively utilized. You can easily and safely share access to the insights by [inviting collaborators](https://platform.zapier.com/quickstart/invite-team-member#collaborator) to the integration without giving them permissions to make changes to it.
 
-## How to Make a New Version of Your Integration
+## How to make a new version of your integration
 
 Sometimes you may want to add something new to your integration. You may need to fix bugs in your integration, or add additional details to resolve user issues. You might want to add additional triggers, actions, or searches to your integration as uses request them. Or, over time, you may need to change your app's authentication and API calls.
 
-The Zapier platform makes it easy to build new versions of your integration when needed. You can create new versions for minor or major changes as needed.
+The Zapier Platform makes it easy to build new versions of your integration when needed. You can create new versions for minor or major changes as needed.
 
 Versions that have been made public, or those with more than 5 users, cannot be edited. In that case, you will need to create a new version to make any changes. This is so that existing users are not surprised by changes to their running workflows.
 

--- a/docs/_partners/integration-examples.md
+++ b/docs/_partners/integration-examples.md
@@ -1,16 +1,17 @@
 ---
-title: Integration Examples
-order: 8
+title: Integration design examples
+order: 5
 layout: post-toc
 redirect_from: /partners/
 ---
 
-# Integration Design Examples
+# Integration design examples
 
 Each app has its own unique features, but there are also a number of similarities between apps in similar categories. Here are some examples to keep in mind when designing a [form](#form), [CRM](#crm), or [project management](#pm) app integration:
 
 <a id="form"></a>
-## Add a Form or Survey App to Zapier
+
+## Add a form or survey app to Zapier
 
 Form and Survey apps—along with similar apps for polls, applications, and mobile data collection—are ideal apps to integrate with Zapier. Whenever someone fills out the form, that new data needs to go somewhere. Zapier can connect that form to create new contacts, document templates, messages, and more.
 
@@ -18,7 +19,7 @@ Here are things to keep in mind when adding a form-based app to Zapier.
 
 ### Triggers
 
-#### Add a New Entry/Response Trigger
+#### Add a new entry/response trigger
 
 ![Form app on Zapier](https://cdn.zapier.com/storage/photos/419a35068b794c36a9253a31a309e21d.png)
 
@@ -26,7 +27,7 @@ The most common trigger for a form or survey app is a "New Form Entry/Submission
 
 Using our standard "New xxx" naming pattern makes it clear to users that Zapier only retrieves new entries, not existing ones.
 
-#### Let Users Select a Specific Form
+#### Let users select a specific form
 
 ![Select Form in Zapier](https://cdn.zapier.com/storage/files/f951d24a065e5a2c56665e51002e7e17.gif)
 
@@ -36,9 +37,9 @@ Add a [dynamic dropdown](https://platform.zapier.com/docs/input-designer#how-to-
 
 You could make the form selector required, so the trigger only watches for results from this one form, which is the recommended option. Or, you could make the field optional so it would trigger for responses to any form; if so, add help text to let users know what to expect if they do not select a form.
 
-### Format Trigger Response
+### Format trigger response
 
-#### Question and Answer Fields
+#### Question and answer fields
 
 ![Example Form field names](https://cdn.zapier.com/storage/photos/554f4fc4856a555714398088f7a162b2.png)
 
@@ -52,13 +53,13 @@ For example, a common use case is to log responses in spreadsheets, with each an
 
 Consider including the question number as a prefix to the label as well, to make it even easier for users to find specific questions and fields.
 
-#### Multiple Choice Fields
+#### Multiple choice fields
 
 ![Multiple Choice Fields](https://cdn.zapier.com/storage/photos/033953ce0537c18a6efbe47f783ddf5a.png)
 
 If a multiple choice question is based on a spectrum of values (e.g., from "not really" to "very"), it’s sometimes useful to return the choice values (such as `1` to `5`) as well as the actual answer. This can be especially useful for tracking responses in a spreadsheet.
 
-#### Multi-select Fields
+#### Multi-select fields
 
 ![multi-select field](https://cdn.zapier.com/storage/photos/e922d705c9f9d61c46f32b31ba03e53f.png)
 
@@ -72,7 +73,7 @@ Consider returning these responses individually. Split each individual response 
 
 Or, return all the selected values in a single, comma separated response. Users can then easily split the responses themselves with Zapier's [Formatter](https://zapier.com/help/formatter/#using-split-text) tool, or could map the responses together to another field.
 
-#### Date Fields
+#### Date fields
 
 ![Date field from form](https://cdn.zapier.com/storage/photos/291cb5f3b048bcf6cda769f93408128d.png)
 
@@ -80,15 +81,15 @@ Return the timestamp when the response was completed, at a minimum, in [ISO 8601
 
 Consider also including a human-friendly date for the response completion and any other selected dates from the form.
 
-#### File Attachments
+#### File attachments
 
 If users can attach files to form responses, include those in the response data as well. Zapier can request the full file via [file dehydration](https://zapier.github.io/zapier-platform-cli/#file-dehydration), or your app can return a URL for the file.
 
-### Technical Configuration
+### Technical configuration
 
-#### REST Hooks
+#### REST hooks
 
-If possible, use [REST Hooks](https://platform.zapier.com/docs/triggers#rest-hook-trigger) for your trigger, as they will send new form entries to Zapier as soon as the form is filled out. If you have a lot of form entries in a short space of time, webhooks can make your integration more robust, as with polling, there is a chance the number of new entries will exceed your page size of polling results. Additionally, with REST hooks, Zapier won't repeatedly poll your API to check for new responses.
+If possible, use [REST hooks](https://platform.zapier.com/docs/triggers#rest-hook-trigger) for your trigger, as they will send new form entries to Zapier as soon as the form is filled out. If you have a lot of form entries in a short space of time, webhooks can make your integration more robust, as with polling, there is a chance the number of new entries will exceed your page size of polling results. Additionally, with REST hooks, Zapier won't repeatedly poll your API to check for new responses.
 
 The format of the key/values in a hook should match the format for a polling URL item.
 
@@ -104,7 +105,7 @@ Zapier requests sample results for every trigger and action, so users can still 
 
 Instead, include the bare set of common form fields from every result, such as the form ID and timestamp.
 
-### Form or Survey Integration Test Checklist
+### Form or survey tntegration test checklist
 
 Once you’ve built a “New Form Entry” trigger, make Zaps for the following items to ensure your integration works well:
 
@@ -117,7 +118,7 @@ Then submit new entries to your form to check that the Zaps run as expected when
 
 <a id="crm"></a>
 
-## Add a CRM or Contacts App to Zapier
+## Add a CRM or contacts app to Zapier
 
 CRM—or customer relationship management—apps are more than just a list of contact details. They're detailed databases that link contacts with companies, companies with deals, and more. That makes them a bit more tricky to integrate with Zapier than many other apps where each bit of data stands alone.
 
@@ -125,7 +126,7 @@ Here are things to keep in mind to make your CRM integration deliver the experie
 
 ### Triggers
 
-#### Include Triggers For Every Common Item
+#### Include triggers for every common ttem
 
 Users typically expect the following types of triggers for CRM apps. If your app uses a different name for these items, use the name that appears in your UI so your customers know exactly what to expect:
 
@@ -138,11 +139,11 @@ Users typically expect the following types of triggers for CRM apps. If your app
 * New Contact in View (also: Filter)—useful to trigger when contacts meet specific criteria
 * New Deal in Stage (also: Group, Segment, or Contact in Stage)—useful to trigger when a deal progresses, if your CRM includes a way to track deal stages
 
-#### Use Separate New and Updated Triggers
+#### Use Separate new and updated triggers
 
 Use "New x" triggers only for new items. If you want a way to track updated items, add "Updated x" triggers for those items. That way users can build Zaps that fit their workflows depending on if a contact is new or updated.
 
-#### Include Filter Options
+#### Include filter options
 
 ![Filter options in a CRM](https://cdn.zapier.com/storage/photos/5dddfc827be95b7125cec7c27ab716bc.png)
 
@@ -150,11 +151,11 @@ Some apps, such as Pipedrive and Salesforce, let users add custom filters or vie
 
 Ordering the dropdown list by most recently added so users can easily find the filter or view they need.
 
-### Technical Configuration
+### Technical configuration
 
-#### REST Hooks
+#### REST hooks
 
-We recommend you use [REST Hooks](https://platform.zapier.com/docs/triggers#rest-hook-trigger) if possible, so new contacts start Zaps as soon as they're added. This is especially helpful if users import hundreds of contacts to your app, which a paging trigger's API response may not be able to handle.
+We recommend you use [REST hooks](https://platform.zapier.com/docs/triggers#rest-hook-trigger) if possible, so new contacts start Zaps as soon as they're added. This is especially helpful if users import hundreds of contacts to your app, which a paging trigger's API response may not be able to handle.
 
 #### Update Triggers
 
@@ -162,7 +163,7 @@ Updated triggers should run whenever an item has new data added, or when relatio
 
 If you are using polling triggers, this may cause issues with [how Zapier performs deduplication](https://platform.zapier.com/docs/dedupe), as we don’t consider the status, stage, or tag to be newly applied to that contact anymore. You may need to customize your API call's code to add a timestamp to the id field you’re using for deduplication so that the Zap triggers each time the record is updated.
 
-### Trigger Response Format
+### Trigger response format
 
 #### Polling URL
 
@@ -170,7 +171,7 @@ The polling URL should return the most recent record created, so users can set u
 
 If there are no recent new records, return an empty array. Zapier will then encourage the user to create a sample then re-test their trigger and finish mapping their Zap.
 
-#### Obtaining Linked Information 
+#### Obtaining linked information 
 
 Records in CRMs don't stand alone—they are only one part of a linked ecosystem of data. Getting the full context of linked information is useful. For example, if your trigger is "New Contact" and newly added contacts are linked to organizations, users expect to get full organization data, too.
 
@@ -178,7 +179,7 @@ Linked information should include both IDs to easily map them to your app’s ac
 
 If your record API endpoint does not automatically return additional linked data beyond the ID or name of the record, you will need to add custom code to your trigger API call to fetch the linked record as well.
 
-#### Custom Fields
+#### Custom fields
 
 If your customers typically use custom fields, make sure Zapier pulls in every custom field with [pagination](https://platform.zapier.com/docs/triggers#how-to-use-pagination).
 
@@ -188,7 +189,7 @@ If possible, return tags on records as an array of strings or a comma-delimited 
 
 ### Searches
 
-#### Include Common Search Actions
+#### Include common search actions
 
 Users typically expect to have the following searches for a CRM integration:
 
@@ -198,7 +199,7 @@ Users typically expect to have the following searches for a CRM integration:
 
 Each should find an existing record, and return it in the same format that the trigger returns records. This ensures that the user gets a consistent experience and can use data from triggers and searches the same way.
 
-### Offer Multiple Search Options
+### Offer multiple search options
 
 ![Infusionsoft Zapier Search Options](https://cdn.zapier.com/storage/files/5395ac18091a4fe7506d5b5e4a8ced60.gif)
 
@@ -206,17 +207,17 @@ If possible, let users search for items by a search key as well as a search valu
 
 For a "Find Contact" search, for example, consider letting users search by Email, ID, or Name.
 
-### Prevent Deduplication Problems
+### Prevent deduplication problems
 
 If your CRM doesn’t allow multiple records that have the same value for a field (such as email), consider offering only a single search query for that field instead of providing multiple options. This prevents users from searching on a different field, trying to create a new record, and then being told that a record with that email already exists.
 
-### Offer Parity Across Triggers
+### Offer parity across triggers
 
 Ensure that the field(s) you offer for search are fields that are returned by the trigger steps. For example, a user might use a *New Contact* trigger, and then want to find out more information about the organization the contact is associated with by using a *Find Organization* search. If the *New Contact* trigger only provides the associated organization ID, it doesn’t make sense for the *Find Organization* search to only allow searches for the organization name.
 
 In the same vein, include linked information in search results as in triggers.
 
-#### Error Handling
+#### Error handling
 
 ![Halt a Zap instead of showing an error](https://cdn.zapier.com/storage/files/a57ed995196cb44caf4dd813ac6c60aa.gif)
 
@@ -226,7 +227,7 @@ If a record cannot be found, ensure that it returns a halted exception instead o
 
 ### Actions
 
-#### Include Common Create Actions
+#### Include common create actions
 
 Users typically expect to have the following types of create actions for CRM apps, with either *Create* or *Add* as the first word in the title:
 
@@ -245,7 +246,7 @@ It’s also useful to include Update actions, as information on records in CRMs 
 
 You don't need to add all of these actions in the first version of your integration, but over time these are all actions that may be good to add into your integration
 
-#### Allow Linked Records
+#### Allow linked records
 
 ![Linked Record](https://cdn.zapier.com/storage/photos/19fad8f7f1b3ae44be4425760901329c.png)
 
@@ -253,17 +254,17 @@ Your CRM integration will be especially powerful if users can link other record 
 
 That said, do not have one action create multiple items. When a user creates a new contact through Zapier, this should only create new contacts, and should not also create other linked records at the same time. Instead, include a separate action to create the other linked record, along with a contact update action to link the contact after the other record is created. This reduces the chance for errors and record redundancy.
 
-#### Bring in All Custom Fields
+#### Bring in all custom fields
 
 Custom fields should be displayed with a human-readable label instead of the internal ID. If the custom fields are radio selects, booleans, or can only accept certain values, add them as [static or dynamic dropdowns](https://platform.zapier.com/docs/input-designer#dropdown) in Zapier.
 
-#### Support Workflows
+#### Support workflows
 
 ![CRM workflows in Zapier](https://cdn.zapier.com/storage/photos/ce412bf1bf164bdcde6f624c3ec59fe8.png)
 
 If your app has the lets new records get automatically added to in-app workflows, sequences, follow-ups, or campaigns, make sure records created by Zapier will also get automatically added to workflows. You can also add a boolean field to your action input field to let users select if they want this contact added to a workflow, or include a dynamic dropdown to select the workflow they want.
 
-### CRM Integration Test Checklist
+### CRM integration test checklist
 
 Once you've built your CRM integration, create Zaps for the following scenarios to test your integration and ensure it works as expected:
 
@@ -272,13 +273,14 @@ Once you've built your CRM integration, create Zaps for the following scenarios 
 * If you have the option to link records in your integration's actions, check to see that these are linked correctly when creating records.
 
 <a id="pm"></a>
-## Add a Project Management or Tasks App to Zapier
+
+## Add a project management or tasks app to Zapier
 
 You often can't automate the work in your projects, but you can automatically add tasks, spin up new projects, and keep track of what's done with a Zapier product management app integration. Here are the things your users will expect in your integration
 
 ### Triggers
 
-#### Include Popular Triggers
+#### Include popular triggers
 
 Be sure to include at least the following triggers, depending on what your app supports:
 
@@ -302,7 +304,7 @@ Then, consider adding update triggers as well. More than in most other apps, use
 * Completed Project
 * Project moved to Stage (also: Project Changed Status)
 
-#### Watch Out For Permissions
+#### Watch out for permissions
 
 Project Management apps are typically used in a team, so it’s important to ensure that Zaps also trigger on teammates’ activity. For example, if user A creates a Zap that collects comments on projects, they’ll want to know if user B comments on projects as well. 
 
@@ -310,7 +312,7 @@ Permissions may also fluctuate depending on if someone is an admin/creator of a 
 
 If this is not possible with your API, we recommend making this clear in the Trigger description. For example, for a _New Note_ trigger, add help text such as "Triggers when the connected user account adds a note to a project."
 
-#### Include Trigger Options
+#### Include trigger options
 
 ![Trigger Options](https://cdn.zapier.com/storage/photos/4fad8819e9d09ca9fc3b590afe64d947.png)
 
@@ -318,7 +320,7 @@ Add Trigger options so users can select which records they want to receive. For 
 
 Order the dropdown list by most recently added to make it easier for users to find their current project.
 
-#### Obtain Linked Information
+#### Obtain linked information
 
 ![Linked Data in Podio Zapier](https://cdn.zapier.com/storage/photos/8ec62dd77f8278ff1626b9c2cf1be47d.png)
 
@@ -330,7 +332,7 @@ If your API doesn't return linked data by default, add custom code to your API c
 
 ### Searches
 
-#### Include Popular Searches
+#### Include popular searches
 
 Users typically expect to be able to find the broader items that organize their projects, including:
 
@@ -342,7 +344,7 @@ Users will typically want to find top-level records so they can add child-level 
 
 Searches should find an already existing record, and return it in the same format and with the same data as triggers use, for a consistent experience.
 
-#### Offer Multiple Search Options
+#### Offer multiple search options
 
 ![Project Management Search Options](https://cdn.zapier.com/storage/photos/df5c2a77049abfa967e32f043d14811e.png)
 
@@ -352,7 +354,7 @@ Additionally, project name searches should exact matches first. It’s likely th
 
 ### Actions
 
-#### Include Popular Create Actions
+#### Include popular create actions
 
 Users typically expect to be able to create everything they could in your app. Use *Create* or *Add* to prefix each action:
 
@@ -368,7 +370,7 @@ Because projects are very dynamic and are often organized across several apps, w
 * Complete Task (also: Todo, Subtask, Card. You might try "Update Task Status" if it’s appropriate for your API as well.)
 * Update Event
 
-#### Let User Link Records
+#### Let user link records
 
 ![Create Action Search](https://cdn.zapier.com/storage/photos/acd4cd6c45be3b17d74b597c1327f282.png)
 
@@ -376,7 +378,7 @@ Your integration will be especially powerful if users can link other record type
 
 Only create one record with one Zapier action, though. When a user creates a new Event through Zapier, this should only create new Events, and should not also create other linked records at the same time. This reduces opportunity for error as well as record redundancy for the user.
 
-### Project Management Integration Test Checklist
+### Project management integration test checklist
 
 Once you've built your project management app integration, set up a few Zaps to test out popular scenarios:
 

--- a/docs/_partners/integration-quality.md
+++ b/docs/_partners/integration-quality.md
@@ -1,11 +1,11 @@
 ---
-title: Assessing and Improving your Integration's Quality
-order: 4
+title: Assessing and improving your integration's quality
+order: 8
 layout: post-toc
 redirect_from: /partners/
 ---
 
-# Assessing and Improving your Integration's Quality
+# Assessing and improving your integration's Quality
 
 Integration quality on Zapier boils down to two main pillars: **Health** and **Depth**.
 
@@ -19,12 +19,12 @@ We’ll examine the main metrics around integration health and explore what they
 * **Bugs**
 * **Active users retention**
 
-Utilize the various tools and resources available in the developer platform, such as [Bugs and Feature Requests](https://platform.zapier.com/partners/feature-requests-bugs#how-to-monitor-feature-requests-and-bugs), [Monitoring](https://platform.zapier.com/docs/testing#monitoring), and your integration’s Dashboard to monitor and analyze these metrics and your integration’s health. Let’s dig in!
+Utilize the various tools and resources available in the developer platform, such as [bugs and feature requests](https://platform.zapier.com/partners/feature-requests-bugs#how-to-monitor-feature-requests-and-bugs), [monitoring](https://platform.zapier.com/docs/testing#monitoring), and your integration’s dashboard to monitor and analyze these metrics and your integration’s health. Let’s dig in!
 
-## How to View Insights
+## How to view insights
 
 1. Sign into [Zapier Developer Platform](https://developer.zapier.com/) through your Zapier account to see integrations you can access.
-2. Select an integration to view its insights. You **MUST** be an admin or collaborator to view an integration’s Dashboard.
+2. Select an integration to view its insights. You **must** be an admin or collaborator to view an integration’s dashboard.
     * If an integration isn’t listed, ask an admin to invite you or try [adding yourself as a collaborator](https://developer.zapier.com/join-integration).
 3. Navigate to “Dashboard” in the lefthand sidebar to view growth and usage insights.
 
@@ -41,11 +41,11 @@ Errors can cause pain for users at two vital points:
 
 We don’t want integrations throwing errors unnecessarily, but not all errors are necessarily bad. It’s perfectly acceptable for your integration to throw errors, as long as [they are meaningful](https://platform.zapier.com/partners/integration-review-guidelines#7-error-handling) in stating the problem and ideally the resolution, and [handled correctly](https://platform.zapier.com/cli_docs/docs#error-handling). For example, warnings due to user error or duplications are appropriate to throw and not an issue of the integration itself. So, it’s helpful to identify which errors are actual errors of the integration’s functionality.
 
-### What we have learned
+### Key Zapier insights
 
 Spikes in errors should be monitored as leading indicators of problems users are facing within your integration. The more descriptive and thorough [error handling](https://platform.zapier.com/cli_docs/docs#error-handling) your API and integration have in place, the easier it will be for users to resolve their own issues and for Zapier’s support team to assist with debugging.
 
-### Best Practices
+### Best practices
 
 If you don’t have control to make changes to the API itself, utilize custom error handling to improve your error messages:
 
@@ -70,11 +70,11 @@ Not necessarily. Maybe the user started to make a Zap, put the kettle on, forgot
 
 It can also highlight that certain triggers or actions are proving challenging to set up in a Zap or are erroring when run. Perhaps your trigger sample doesn’t return custom fields the user is looking to map in the Zap or the user gets confused by unclear input fields while setting up their action; these are two of many reasons why users abandon Zap setup. 
 
-### What we have learned
+### Key Zapier insights
 
 Zap activation rates at the individual trigger and action level are a great leading indicator of performance and usability. Don’t forget about the authentication step in your integration too! If users can't authenticate or get their Zaps enabled and activated, they stand little chance of ongoing success.
 
-### Best Practices
+### Best practices
 
 Give users the best chance to successfully activate their Zaps by making the integration as familiar and easy-to-use as possible:
 
@@ -98,13 +98,13 @@ Here are a couple things to note about bugs:
 
 Don’t forget the affected user counts on issues underrepresent the actual totals, as only a small portion of all users facing an issue take the time to contact support. If a significant number of users have made the effort to contact support to say they are affected by a bug in the integration, it should raise flags.
 
-### What we have learned
+### Key Zapier insights
 
 Open bugs are one of the best indicators of an integration’s health. If users are contacting Zapier’s support team to tell us about problems, we take that as a strong signal something is broken and needs to be fixed.
 
 Regardless of the size of your integration’s user base, keeping the percent of monthly active users affected by open bugs under double figures (and ideally at 0) is recommended for a healthy integration.
 
-### Best Practices
+### Best practices
 
 * Instead of a “set-it-and-forget-it” mentality, allocate ongoing resources in your team's product roadmap for the maintenance of your Zapier integration to avoid surprise work or gaps in functionality.
 * Need help with maintenance? [Match with a Zapier Expert](https://zapier.com/experts/matchmaking) to help you fix one-off bugs or maintain your integration.
@@ -114,19 +114,19 @@ Regardless of the size of your integration’s user base, keeping the percent of
 
 At Zapier, churn means a user used your integration in their Zaps 29 - 56 days ago, but hasn’t run a successful task in one of those Zaps in the past 28 days. This user is considered to have churned from the integration. From the opposite perspective, we can look at active users retention, or the percentage of users who haven’t churned.
 
-### Did they leave Zapier altogether?
+### Did users leave Zapier altogether?
 
 Not necessarily. Maybe they switched to using a competing integration or their workflow had a more periodic or seasonal cadence.
 
 But, it could also mean they got so frustrated with the experience of trying to get their Zap working and _keep_ it working successfully, they turned it off, deleted it, and walked away.
 
-### What we have learned
+### Key Zapier insights
 
 Lowered active user retention rates don’t necessarily mean poor integration health. Some apps lend themselves to use-cases with shorter life-spans than others. That said, spikes in churn rate not related to seasonal variations in usage could be indicators of a problem with something not functioning as expected.
 
 Active user retention is not a leading indicator. In fact, it’s quite a lagging one that may only start indicating a problem up to 28 days after it has been an issue. That doesn’t deem it useless, we just have to know how to make full use of it.
 
-### Best Practices
+### Best practices
 
 Approaching active user retention with a long-term strategy can help maintain a consistently high level of retention:
  
@@ -135,9 +135,9 @@ Approaching active user retention with a long-term strategy can help maintain a 
 * Update the integration regularly with features as your platform evolves. [Invite stakeholders to your integration](https://platform.zapier.com/quickstart/invite-team-member) to give them admin or read-only access to insights, metrics, and feedback to prioritize and align improvements. 
 
 
-## Integration Insights Definitions
+## Integration insights definitions
 
-The following includes definitions for each of the metrics provided in the integration Dashboard:
+The following includes definitions for each of the metrics provided in the integration dashboard:
 
 | **Metric**                  | Definition                                                                              | Available Filters   |
 |-----------------------------|-----------------------------------------------------------------------------------------|---------------------|
@@ -154,7 +154,7 @@ The following includes definitions for each of the metrics provided in the integ
 | **Usage by action**         | Number of current live Zaps (Zaps turned on), paused Zaps (Zaps turned off), and total Zaps for each action.   | By integration version                       |
 
 
-## Practical Applications of Integration Insights
+## Practical applications of integration insights
 
 * Launching a co-marketing campaign or running ads? Track daily and monthly MAU over the launch period to track changes in usage.
 * Noticing certain triggers and actions with higher activations? Create additional Zap Templates to expand usage further since you know they are popular functionality.

--- a/docs/_partners/integration-review-guidelines.md
+++ b/docs/_partners/integration-review-guidelines.md
@@ -1,11 +1,11 @@
 ---
-title: Zapier Integration Review Guidelines
-order: 9
+title: Zapier integration review guidelines
+order: 3
 layout: post-toc
 redirect_from: /partners/app-review-guidelines
 ---
 
-# Zapier Integration Review Guidelines
+# Zapier integration review guidelines
 
 ## Introduction
 
@@ -15,47 +15,49 @@ When you follow these guidelines, your Zapier integration can pass our review pr
 
 Below you will find our latest guidelines arranged into clear, multiple sections: [General](https://platform.zapier.com/partners/integration-review-guidelines#1-general), [Meta](https://platform.zapier.com/partners/integration-review-guidelines#2-meta), [Authentication](https://platform.zapier.com/partners/integration-review-guidelines#3-authentication), [Triggers](https://platform.zapier.com/partners/integration-review-guidelines#4-triggers), [Actions](https://platform.zapier.com/partners/integration-review-guidelines#5-actions), [Searches](https://platform.zapier.com/partners/integration-review-guidelines#6-searches), [Error Handling](https://platform.zapier.com/partners/integration-review-guidelines#7-error-handling), and [Code](https://platform.zapier.com/partners/integration-review-guidelines#8-code).
 
-Some important points to note:
+### Key considerations
 
 * Because the Zapier Platform is always changing and improving to keep up with the needs of our customers, this is a living document.
-* Making your integration public on Zapier is a great way to reach millions of users around the world. If you’d like to use your integration with only a small group of people or if the Zapier Platform guidelines are not suitable to you, consider keeping your integration private via the invite-only status, and invite specific users directly to your integration.
-* We support diverse views being represented on the Zapier Platform, as long as your integration is respectful to users with differing opinions and the quality of the user experience is up to par. Integrations with content or behavior the integration reviewer deems inappropriate, discriminatory, or ‘over the line’ will be rejected.
-* We reserve the right to remove users from the Zapier Platform and remove integrations from Zapier if there is evidence of not following these guidelines (for example, by trying to game the review process, steal user data, or manipulate test users).
+* If you prefer your integration to be accessible to a limited group of users, or if the Zapier integration review guidelines do not align with your requirements, you might want to consider maintaining your integration as private. Learn more about [private vs public integrations](https://platform.zapier.com/private_integrations/private-vs-public-integrations).
+* We encourage diversity on the Zapier Platform, provided your integration respects users with varying viewpoints and ensures a high-quality user experience. Any integration found to contain or exhibit behaviour deemed inappropriate, discriminatory or crossing acceptable boundaries will be rejected
+* We reserve the right to remove users from the Zapier Platform and remove integrations from Zapier if there is evidence of not following these guidelines. This includes attempts to exploit the review process, illicitly acquire user data, or manipulate test users.
 
-## Before You Submit
 
-Before submitting your Zapier integration for review, make sure you are familiar with the following criteria the Zapier team uses during reviews:
+## Pre-submission checklist
 
-* Ensure your integration is complete, and you've tested your integration by creating test Zaps on your end that check for bugs, edge cases, and errors.
-* Focus on key use cases. Check similar integrations in [Zapier’s App Directory](https://zapier.com/integrations/) to get some ideas on which items to include in your integration and keep your first release lean. You can always add more functionality later.
-* Ensure all integration information and metadata is complete and accurate. Be sure to follow [Zapier’s standards for integration branding](https://platform.zapier.com/partners/planning-guide#how-to-brand-your-zapier-integration) to help your integration fit into the Zapier ecosystem well.
+
+Before submitting your[ Zapier integration for app review](https://coda.io/d/_d-clruQiSri/_suH72#_luOj4), familiarize yourself with the criteria the Zapier team uses during app reviews:
+
+* Confirm your integration is fully developed and has undergone thorough testing. This includes creating test Zaps on your end that check for bugs, edge cases, and errors.
+* Focus on primary use cases. Review similar integrations in [Zapier’s App Directory](https://zapier.com/integrations/) for inspiration on which features to include in your integration.
+* Ensure all integration information and metadata is complete and accurate. Be sure to follow[ Zapier’s standards for integration branding](https://platform.zapier.com/partners/planning-guide#how-to-brand-your-zapier-integration) to help your integration fit into the Zapier ecosystem well.
 * Provide an active demo account and login credentials, plus any other resources that might be needed to review your integration (e.g. login credentials to your product under integration-testing@zapier.com as the username/email and dummy credit card credentials used to test making purchases, if applicable to your integration). We may need to test triggers, actions, or searches in your integration during review, so please provide us with access to the appropriate platforms and resources to do so.
-* Test early with real users. Use our [invite links to beta test](https://platform.zapier.com/docs/testing#how-to-invite-others-to-test-new-integrations) the integration.
+* Test early with real users. Use our[ invite links to beta test](https://platform.zapier.com/docs/testing#how-to-invite-others-to-test-new-integrations) the integration.
 * Enable backend services so they’re live and accessible during review.
 * Include detailed explanations of non-obvious features in the publishing request notes, including supporting documentation where appropriate. If we cannot understand aspects of your integration during the review, we may reject it.
-* Focus on ease of use. If you haven’t yet, please read [How Zapier Works](https://zapier.com/help/how-zapier-works/) and set up a few Zaps to get a sense of the user experience.
+* Your developer should review the[ integration check reference documentation](https://platform.zapier.com/partners/integration-review-guidelines) to make sure all common technical issues are addressed.
 
 ## 1. General
 
 ### 1.1 Familiarity with Zapier
 If you haven’t used Zapier before, [sign up](https://zapier.com/sign-up/) for a free account and try a few popular integrations before building your integration. This will help you understand how Zapier works, how your users will set up Zaps, and how your integration can best fit into Zap workflows.
 
-### 1.2 Key Use Cases
+### 1.2 Key use cases
 Your triggers, actions, and searches should focus on the main use cases of your platform. Check similar integrations in [Zapier’s App Directory](https://zapier.com/integrations/) to get some ideas on which items to include in your integration.
 
-### 1.3. Integration Testing
+### 1.3. Integration testing
 Test your integration early and often, both internally and externally during the build stage. This will help you catch bugs and identify any usability issues early on that you otherwise will be asked to address during the review process, which may extend the time to launch.
 
 #### 1.3.1 Internal Testing
 * Create test Zaps in your developer account with each of the triggers, actions, and searches in your integration, and run them, so each have some successful runs in the Zap History. This lets you experience firsthand the Zap setup process our mutual users will go through, and lets you validate the triggers, actions, and searches look and work as intended. We may ask you to share your test Zaps with us when you submit your integration for review.
 
-#### 1.3.2 External Testing with Real Users
+#### 1.3.2 External testing with real users
 * Share your integration's [invite link](https://platform.zapier.com/docs/testing#how-to-invite-others-to-test-new-integrations) before you request a review to give users access to the integration and to gather early feedback. Seeing unique and active users gives us confidence the integration is useful and successfully working for many users.
 
-### 1.4 Consistency in Style
-The terminology and features in your Zapier integration should be consistent with the terminology and features seen in your product's own UI. We strive to give users a consistent experience throughout Zapier, so your integration should also be consistent with the style used in other popular Zapier integrations. Be sure to follow [Zapier’s Branding and Design Guidelines](https://platform.zapier.com/partners/planning-guide#how-to-brand-your-zapier-integration) to ensure your integration suits the Zapier ecosystem well.
+### 1.4 Consistency in style
+The terminology and features in your Zapier integration should be consistent with the terminology and features seen in your product's own UI. We strive to give users a consistent experience throughout Zapier, so your integration should also be consistent with the style used in other popular Zapier integrations. Be sure to follow [Zapier’s integration branding and design guidelines](https://platform.zapier.com/partners/planning-guide#how-to-brand-your-zapier-integration) to ensure your integration suits the Zapier ecosystem well.
 
-### 1.5 Valid Test Account
+### 1.5 Valid test account
 The Zapier team verifies each trigger, action,and search in the integration to verify they function consistently with the platform. To do so, please set up a valid test account on your platform and share the test credentials with our team via the publishing form. Further requirements for the test account are below:
 
 * Create the test account using integration-testing@zapier.com, so we have access to the Forgot Password flow.
@@ -64,29 +66,29 @@ The Zapier team verifies each trigger, action,and search in the integration to v
 * Provide a demo video or detailed documentation to the Zapier team if testing any features requires an environment that is difficult to replicate or requires specific hardware.
 * Supply any other necessary credentials/resources and configure the test account so it’s ready to test. For example,  providing dummy payment data if your integration requires making payments, or configuring your plugin/embed on a test site to send us. Do not give super admin access or enable any features or settings on the test account that are only available to internal employees, and not available to users.
 
-### 1.6 Completeness and Platform Consistency
+### 1.6 Completeness and platform consistency
 Submit your integration for review only when it is complete and ready to be published. Make sure it is thoroughly tested for edge cases, and does not have any bugs when submitting. Both your product and integration need to work consistently without errors. Products not yet fully launched to the public (app is invite-only or for beta users only) and integrations using sandbox/test/dev environments or endpoints will be asked to remain private until they are ready to be publicly available. Once the app is published, it is visible in the Zapier App Directory and it would be expected that any of our mutual users would be able to connect the application to Zapier.
 
 See the following guideline regarding “Repeated Submission” for more information. We will not allow incomplete or error-ridden integrations to become public.
 
-### 1.7 Repeated Submission
+### 1.7 Repeated submission
 Submitting multiple integrations that are essentially the same ties up the Zapier process and risks the rejection of all the integrations. Please be thoughtful and consider combining your integrations into one where it makes sense. Also, please do not flood the Zapier team with multiple, consecutive submissions of the same integration while going through the review process. Violating this policy will result in slower review times for your integration or further penalties.
 
-### 1.8 Misleading or Malicious Functionality
+### 1.8 Misleading or malicious functionality
 Your integration must perform as advertised and should not give users the impression the integration is something it is not. If your integration appears to promise certain features and functionalities, it needs to deliver. Do not create a Zapier integration that can be used to spam, phish, or send unsolicited messages to users. If you attempt to cheat the system (for example, by trying to trick the review process, steal user data, or fake real users) your integration will be removed from Zapier and you could be expelled from submitting any integrations in the future. False information and features, including inaccurate data or joke functionalities, such as fake phone calls or SMS are prohibited.
 
-### 1.9 Objectionable Content
+### 1.9 Objectionable content
 Integrations should not include content that is discriminatory, defamatory, offensive, mean-spirited, or insensitive with regards to gender, religion, sexual orientation, age, race, national/ethnic origin, or other targeted groups.
 
 ## 2. Meta
 
-### 2.1 Integration Ownership
+### 2.1 Integration ownership
 The Zapier team needs to ensure the account owning the integration has proper access to associated platform and API, either by working for, being associated with, or being contracted by the company whose integration is in review. This is so we can reach out with questions or support issues during the review and after the integration is public. If it’s not obvious to us the owning account is associated with your integration's company (largely by email domain), we will request proof via an email from a matching domain as the platform or confirmation from someone at the company.
 
 Here are some further scenarios of what integrations are permitted on the Zapier platform by status, ownership, and intention:
 
 * Anyone can build a private integration.
-* Integrations by developers who work for or third-party developers (preferably a [Trusted Developer](https://zapier.com/developer/documentation/v2/integration-developers-partners/)) hired by the company owning the API and intended to go public are permitted to the invite-only status as a stepping stone before going public. 
+* Integrations by developers who work for or third-party developers (preferably a [trusted developer](https://zapier.com/developer/documentation/v2/integration-developers-partners/)) hired by the company owning the API and intended to go public are permitted to the invite-only status as a stepping stone before going public. 
 * Integrations by developers who work for the company owning the API or have been contracted by the API owner can go public.
 * Integrations by developers who are building on a private API and have no intension of taking their integration public are permitted to remain invite-only indefinitely.
 * Integrations by developers who are building on a public API they do not own and only intend to share with their team (within their company or organization, family and friends, etc.) are permitted to be in invite-only.
@@ -99,16 +101,16 @@ Here are some further scenarios of what integrations are prohibited from the Zap
 * Integrations by developers who are building on a public API they do not own, and routing traffic to their own servers are prohibited from going public or being invite-only. Exceptions apply when building on an approved third-party API.
 * Integrations by developers who do not own the API used in the integration or who have not been given explicit permission by the owners of the API cannot be public.
 
-### 2.2 Developer Information
+### 2.2 Developer information
 Ensure all information provided in the Publishing form is accurate and up-to-date. This helps us reach out to the appropriate contacts when questions or support issues arise. 
 
 #### 2.2.1 Homepage URL
 * The Homepage URL submitted via the Publishing form should be the homepage URL of the application's marketing site.
 
-### 2.3 Replacement Integration
+### 2.3 Replacement integration
 The integration should not already have an equivalent that is Public in our App Directory. Each integration published within the Zapier App Directory should represent a distinct, independent app - to ensure the best experience for our mutual customers. If you’re trying to replace an existing (Legacy) integration, check out the guide on [versions](https://platform.zapier.com/docs/versions) and how to deploy changes. Creating separate integrations for the same app brand is [not allowed.](https://platform.zapier.com/docs/versions#can-i-start-over) 
 
-### 2.4 Multiple Integrations
+### 2.4 Multiple integrations
 Do not create separate integrations for functionality that share the same authentication method and interact with the same API. Consolidate the functionality into one, high-level integration.
 
 ### 2.5 Name
@@ -120,7 +122,7 @@ The logo image must be square, at least 256px on each side, and have a transpare
 ### 2.7 Description
 The integration description is 1-3 sentences or approximately 20-40 words in the form of “<Integration Name'> is a...”. Here’s a good description to follow: https://zapier.com/integrations/slack/integrations. It should describe what your integration is *outside* of the Zapier context, and be free of generic marketing-speak, links, and mentions of Zapier itself. Do not make it appear your integration is associated with or endorsed by Zapier such as “<Integration Name> is Zapier's preferred CRM application.“ And do not use overstated language such “<Integration Name> is the best CRM in the world.”
 
-###  2.8 Category and Role
+###  2.8 Category and role
 Whether your integration is built with the [Platform UI or CLI](https://platform.zapier.com/docs/vs#zapier-platform-ui-vs-cli-which-should-i-choose), be sure to select the most appropriate category to classify your integration by in the Category field and the integration owner’s relationship with your integration in the Role field.
 
 ### 2.9 Language
@@ -128,24 +130,24 @@ We do not have native support for language other than English on the Zapier Plat
 
 ## 3. Authentication
 
-### 3.1 Connecting Accounts
+### 3.1 Connecting accounts
 Make connecting new accounts on Zapier easy for users. [OAuth v2](https://platform.zapier.com/docs/oauth) is the preferred authentication scheme.
 
 * For non-Oauth v2 authentication schemes, users must have the ability to easily generate and retrieve API keys or other required credentials themselves without needing assistance from your support team. 
-* Provide help text with guidance on where users can find their credentials if you’re not using Basic Auth. If possible, provide an embedded link in the help text straight to the page in the platform where users can find the credentials. For example, “Go to the [[API Details](https://www.example.com/manage/api-details)](https://my.xxxx.com/manage/api-details) screen from your <Integration Name> Dashboard to find your API Key.“
+* Provide help text with guidance on where users can find their credentials if you’re not using Basic Auth. If possible, provide an embedded link in the help text straight to the page in the platform where users can find the credentials. For example, “Go to the [[API details](https://www.example.com/manage/api-details)](https://my.xxxx.com/manage/api-details) screen from your <Integration Name> Dashboard to find your API Key.“
 
-### 3.2. Invalid Credentials
+### 3.2. Invalid credentials
 When authenticating with invalid credentials, make sure a user-friendly error message is returned containing information a non-technical user can understand. For example, "Your API Key does not appear to be valid." is better than a generic 401 error message.
 
-### 3.3 Connection Label
-[Connection Labels](https://platform.zapier.com/docs/auth#how-to-add-a-connection-label-to-authenticated-accounts) for authenticated accounts helps users who connect more than one account to their Zapier account distinguish between accounts. Easily identifiable values such as account name, email address, and name work great as Connection Labels, but avoid using sensitive information or non-easily identifiable values such as API Keys, API Secrets, and lengthy IDs as Connection Labels. 
+### 3.3 Connection label
+[Connection labels](https://platform.zapier.com/docs/auth#how-to-add-a-connection-label-to-authenticated-accounts) for authenticated accounts helps users who connect more than one account to their Zapier account distinguish between accounts. Easily identifiable values such as account name, email address, and name work great as Connection Labels, but avoid using sensitive information or non-easily identifiable values such as API Keys, API Secrets, and lengthy IDs as Connection Labels. 
 
-### 3.4 HTTPS Endpoints
+### 3.4 HTTPS endpoints
 For security purposes, all API endpoints used by in integration must use HTTPS versus HTTP. We also require the authentication or login portal to the platform to be hosted on HTTPS.
 
 ## 4. Triggers
 
-### 4.1 Important Triggers
+### 4.1 Important triggers
 We allow integrations to set a maximum of three triggers as ‘Important’ via the [Visibility Option](https://platform.zapier.com/docs/triggers#how-to-add-a-new-trigger-to-a-zapier-integration) in the Visual Builder or the basic [display schema](https://zapier.github.io/zapier-platform-schema/build/schema.html#basicdisplayschema) via the CLI. If you have three or fewer triggers, generally you should set them all as ‘Important’.
 
 ### 4.2 Copy
@@ -158,20 +160,20 @@ Additionally, each trigger must have:
 * a descriptive noun that reflects the object that is being returned in the trigger. This typically is one word and should always be in the singular form. The noun is used around the Zapier platform and will be pluralized automatically to complete various messages to users such as ‘No new <noun> found.‘
 * a concise description using our standard phrasing ‘Triggers when...“ and no more than a handful of additional words. Always the description with a period/full stop. Do not include the name of your integration nor capitalize the noun in the description such a ‘Triggers when a new Lead is created in Example CRM.’ 
 
-### 4.3 Trigger Input Fields
+### 4.3 Trigger input fields
 [Trigger input fields](http:), if they exist, should be named appropriately and include help text if their purpose is ambiguous.
 
-#### 4.3.1 ID Fields
+#### 4.3.1 ID fields
 * Users should never be expected to type in an ID as this is error prone. Your integration should not have any trigger fields labeled ‘<Object Name> ID’, such as ‘Customer ID’. Instead, use Zapier’s [dropdown](https://platform.zapier.com/docs/input-designer) functionality to provide users with a user-friendly list of options.
 
-#### 4.3.2 Help Text
+#### 4.3.2 Help text
 * Don't be redundant with help text, and only include it if you have something different to say from the field name such as  the expected format of the value or additional instructions. Redundant help text teaches users not to read any help text at all, so important information can be missed.
 
-#### 4.3.3 Optional Trigger Fields
+#### 4.3.3 Optional trigger fields
 
 * If a trigger field is optional, confirm the request does not throw an error in a null case where the users does not select an option.
 
-#### 4.3.4 Field Types
+#### 4.3.4 Field types
 * Use the most appropriate [input field type](https://platform.zapier.com/docs/input-designer#zapier-input-field-types) for each of the input fields to show users what type of data to include — though do note the Zap Editor does not validate the data to ensure users added the correct item for that field type. 
 
 * If the field can accept multiple values, use our built in [‘List’ property](https://zapier.github.io/zapier-platform-schema/build/schema.html#fieldschema) or ‘[Allow Multiples’](https://platform.zapier.com/docs/input-designer#allows-multiples) functionality rather than asking users to provide a comma-separated value in a text field.
@@ -179,7 +181,7 @@ Additionally, each trigger must have:
 #### 4.3.5 Ordering
 * Put required trigger input fields at the top of the form with optional fields towards the bottom by importance.
 
-### 4.4 Static Webhooks
+### 4.4 Static webhooks
 Triggers using [static webhooks](https://platform.zapier.com/legacy/docs#static-webhooks) are not allowed in public Zapier integrations. Users can replicate this functionality on Zapier via our built in [Webhooks integration](https://zapier.com/integrations/webhook/integrations). Please consider including authentication and using REST hooks to provide users with a more streamlined experience.
 
 ### 4.5 Polling Triggers
@@ -190,10 +192,10 @@ Live Zaps with [polling triggers](https://platform.zapier.com/docs/triggers#poll
 * Use [pagination](https://platform.zapier.com/docs/triggers#how-to-use-pagination) on the trigger results if large amounts of data will be returned.
 * Each result should contain an explicit ‘id’ field for [deduplication](https://platform.zapier.com/docs/dedupe) from the polling endpoint. By default, the field called `id` will be used as the deduplication key if it exists. Otherwise Zapier looks for the shortest field key with `id` in the key name.
 
-### 4.6 REST Webhooks
+### 4.6 REST webhooks
 [REST hook-based triggers](https://platform.zapier.com/docs/triggers#rest-hook-trigger) are Zapier’s preferred implementation of triggers, since they fire immediately after the triggering action is performed. Here’s a [post](https://zapier.com/engineering/introducing-resthooksorg/) further describing why we and our mutual users prefer REST hook triggers over polling triggers.
 
-#### 4.6.1 Multiple Subscriptions
+#### 4.6.1 Multiple subscriptions
 * Hook based triggers must allow multiple subscriptions without overwriting subscriptions. You can test this by setting up 2 Zaps with the same trigger, turning them On, and confirming  both Zaps fire successfully when the triggering action is performed.
 
 #### 4.6.2 Polling URL
@@ -201,7 +203,7 @@ Live Zaps with [polling triggers](https://platform.zapier.com/docs/triggers#poll
 * Ensure the data returned from the polling URL follows the Polling Trigger guidelines above.
 * Data returned from the polling URL should exactly match the data returned in the hook payload. Be particularly wary field keys from the polling URL and in the hook payload match in spelling and casing.
 
-### 4.7 Response Content
+### 4.7 Response content
 
 #### 4.7.1 Names
 * Many actions in Zapier require names to be split into two fields - first/last or given/surname. This conflicts with some naming schemes around the world, but without a separated name field, your trigger may not be compatible with certain integrations. Always provide separated name fields, though feel free to return the full name as well if the response already includes this.
@@ -220,24 +222,24 @@ Live Zaps with [polling triggers](https://platform.zapier.com/docs/triggers#poll
 #### 4.7.4 Booleans
 * Set boolean values as `true` or `false`. Do not use `1` and `0` or alternative representations for boolean values.
 
-#### 4.7.5 Important Data
+#### 4.7.5 Important data
 * The response data should include important keys in the most usable format. For example, it helps to return both the ID and pretty name of objects, any contact information, and links to the resource (ex: New Card in Trello, link to card).
 
-#### 4.7.6 Unnecessary/Excess Data
+#### 4.7.6 Unnecessary/excess data
 * Remove unnecessary fields that may seem confusing or add noise to users’ Zap setup process. For example, if the response content includes information about the request itself and the input fields provided, please remove those fields from the returned response.
 
-#### 4.7.7 Dropdown Fields
+#### 4.7.7 Dropdown fields
 
 * Return both the name and ID of the selected dropdown option to be used in subsequent steps of a Zap. 
 
-### 4.8 Sample Data
+### 4.8 Sample data
 Each trigger requires [sample data](https://platform.zapier.com/docs/faq#output) for instances where no result is returned during Zap setup. This could be because the API is temporarily down, or because the user has no existing data in their account to return. The sample data must:
 
 * Only represent one item, and not the entire response of the request if there are multiple items returned as a set. For example, {"key": "value"} instead of [{"key": "value"}, {"key": "value2"}, ... ]. 
 * Use representative data in the expected format the values will be returned. For example, don’t set a ‘first name’ key to ‘string’ or ‘1234’; set it to something like ‘Bob’.
 * Be a reflection of the keys returned in every response for all users of the trigger. This means if there are custom fields that will be returned for some users and not others, please do not include these in the sample data.
 
-### 4.9 Output Fields
+### 4.9 Output fields
 [Output Fields](https://platform.zapier.com/docs/faq#output) add user-friendly labels to your API’s response to facilitate mapping fields during Zap setup for users. By default, Zapier will try to make a friendly version of the response by capitalizing words and replacing underscores with spaces, but this can be customized. Add a custom output field label when:
 
 * a field is abbreviated. For example, ‘LTV’ should be labeled ‘Lifetime Value’.
@@ -245,15 +247,15 @@ Each trigger requires [sample data](https://platform.zapier.com/docs/faq#output)
 * a field is represented by an ID.
 * in general, it is not instantly clear what the field or value represents.
 
-### 4.10 Update Triggers
+### 4.10 Update triggers
 Don't offer a generic 'Updated <object name>' trigger, as these are often too general for users to use in their Zaps. Instead, think under what specific scenarios the user needs an update trigger. For example, instead of offering an 'Updated Deal' trigger which triggers when anything changes on the deal, offer a 'New Deal in Stage' or 'Updated Deal Status' trigger that allows the user to specify which stage they want to monitor.
 
-### 4.11 Error Messages
+### 4.11 Error messages
 Users should never receive a successful response if there was an error in the request. All error messages should be user-friendly and avoid technical jargon. Be as specific as possible to what caused the error.
 
 ## 5. Actions
 
-### 5.1 Important Actions
+### 5.1 Important actions
 We allow integrations to set a maximum of three actions as ‘Important’ via the [Visibility Option](https://platform.zapier.com/docs/actions#how-to-add-a-new-action-to-a-zapier-integration) in the Visual Builder or the basic [display schema](https://zapier.github.io/zapier-platform-schema/build/schema.html#basicdisplayschema) via the CLI. If you have three or fewer actions, generally you should set them all as ‘Important’.
 
 ### 5.2 Copy
@@ -266,10 +268,10 @@ Additionally, each action must have:
 * a descriptive noun that reflects the object that is being fired in the trigger. This should typically be one word and should always be in the singular form. The noun is used around the Zapier platform and will be pluralized automatically to complete various messages to users such as ‘No new <noun> found.‘
 * a concise description starting with a plural form of the action verb, and ending in a period/fullstop. For example, the description for a ‘Create Lead’ action could be ‘Creates a new lead.’ Please do not include the name of the platform nor capitalize the noun such a  ‘Creates a new Lead in XXX CRM.’
 
-### 5.3 Action Input Fields
+### 5.3 Action input fields
 All action steps *must* include [input fields](https://platform.zapier.com/docs/actions#2-build-action-input-form) to gather the data needed to create, update, or perform the intended action.
 
-#### 5.3.1 ID Fields
+#### 5.3.1 ID fields
 * Users should never be expected to manually type or map an internal ID to an action field. Your integration should not have input fields labeled ‘XXX ID’. Generally, trigger and action steps of other integrations do not return internal IDs for your specific platform to be used in an action field from your Zapier integration. Use Zapier’s [dynamic dropdown](https://platform.zapier.com/cli_tutorials/dynamic-dropdowns) and [Search Connector](https://platform.zapier.com/legacy/docs#search-connector)/[search-powered field](https://platform.zapier.com/cli_docs/docs#search-powered-fields) functionalities to provide users with an easier way to select or search for the appropriate resource by a more readily-available value such as ‘name’, ‘email address’, ‘title’, etc.
 
 #### 5.3.2 Ordering
@@ -278,25 +280,25 @@ All action steps *must* include [input fields](https://platform.zapier.com/docs/
 * Place all optional, lesser-used fields towards the bottom.
 * Group related fields together. For example, first name and last name fields, as well as individual address component fields should be ordered consecutively. Do NOT use [line-item groups](https://platform.zapier.com/docs/input-designer#how-to-add-a-line-item-group) or the [‘children’](https://zapier.github.io/zapier-platform-schema/build/schema.html#fieldschema) field schema key to visually group fields; these are solely intended for line-item functionality.
 
-#### 5.3.3 Required Fields
+#### 5.3.3 Required fields
 * If a field doesn't have to be required, don't make it! Parallel the required fields from your integration as closely as possible. For example, if 'Email Address' is not required to create a lead in the platform, do not make the 'Email Address' field required in the Zapier editor. If the API specifies a non-important field as required, hard-code a default value so the field is not empty if one is not provided by the user.
 * If the action step has a case where one field OR another field is required, set both fields as optional, add help text to both fields stating that one or the other is required, and throw a user-friendly error message if neither field is filled.
 
-#### 5.3.4 Help Text
+#### 5.3.4 Help text
 * Don't be redundant with help text, and only include it if you have something different to say from the field name such as the expected format of the value or additional instructions. For example, help text for an 'Email Address' field stating 'Contact's email address' is not necessary. Redundant help text teaches users not to read any help text at all, so important information can be missed. You may use [Markdown](https://zapier.com/blog/beginner-ultimate-guide-markdown/) formatting in help text.
 
-#### 5.3.5 Default Values
+#### 5.3.5 Default values
 * Set [default values](https://platform.zapier.com/docs/input-designer#add-fields) for input fields sparsely, but when:
 
 * the API specifies an unimportant field as required, set a default value in case one is not provided by the user.
 * the a field in the platform is set to or shows a default value, set the same default value for the action field in the Zapier integration.
 
-#### 5.3.6 Field Types
+#### 5.3.6 Field types
 * Use the most appropriate [input field type](https://platform.zapier.com/docs/input-designer#zapier-input-field-types) for each of the input fields to show users what type of data to include — though do note Zapier does not validate the data to ensure users added the correct item for that field type.
 
 * If the field can accept multiple values, use our built in [‘List’ property](https://zapier.github.io/zapier-platform-schema/build/schema.html#fieldschema) or ‘[Allow Multiples’](https://platform.zapier.com/docs/input-designer#allows-multiples) functionality rather than asking users to provide a comma-separated value in a text field.
 
-### 5.4 [Response Content](https://zapier.com/developer/documentation/v2/integration-dev-guide/#action-response-content)
+### 5.4 [Response content](https://zapier.com/developer/documentation/v2/integration-dev-guide/#action-response-content)
 Return information about the resource that was created, updated, or affected by the action, and not just a 'success' message. At a minimum, return an ID, the name or title of the resource (when pertinent), and a link to the newly created, updated, or affected resource in the platform (if available). Additionally, return any other useful data about the resource users may need in subsequent actions of a multi-step Zap.
 
 #### 5.4.1 Date-times
@@ -310,27 +312,27 @@ Return information about the resource that was created, updated, or affected by 
 #### 5.4.2 Booleans
 * Set boolean values as `true` or `false`. Do not use `1` and `0` or alternative representations for boolean values.
 
-#### 5.4.3 Important Data
+#### 5.4.3 Important data
 * The response data should include important fields in the most usable format. For example, it helps to return both the ID and pretty name of resources, any important information about the resource such as contact information, and a link to the resource in the platform (ex: New Card in Trello, link to card).
 
 * Returning a link of the newly created/updated/affected resource in the action’s response data helps users link to the resource in subsequent steps of a multi-step Zap and confirms the new resource was created. This is also helpful for our support team when debugging issues.
 
-#### 5.4.4 Unnecessary/Excess Data
+#### 5.4.4 Unnecessary/excess data
 * Remove non-necessary fields that may seem confusing or add unnecessary noise to users’ Zap setup process from your API call’s custom code. For example, if the response content includes information about the request itself and the input fields provided, please remove those fields from the returned response.
 
-#### 5.4.5 Dropdown Fields
+#### 5.4.5 Dropdown fields
 * The response data should include important keys in the most usable format. For example, it helps to return both the ID and pretty name of objects, any contact information, and links to the resource (ex: Find Card in Trello, link to card).
 
 * Return both the name and ID of the selected dropdown option to be used in subsequent steps of the Zap. 
 
-### 5.5 Sample Data
+### 5.5 Sample data
 The ‘Test this Step’ step on actions sends a real request on behalf of the connected account. Therefore, each action requires [sample data](https://platform.zapier.com/docs/faq#output) for instances when the user does not wish to actually run the action in their account to finish setting up the Zap. The sample data must:
 
 * Only represent one record, and not the entire return from the request if there are multiple records returned as a set. For example, {"key": "value"} instead of [{"key": "value"}, {"key": "value2"}, ... ]. 
 * Use representative data in the expected format the values will be returned. For example, don’t set a ‘first name’ key to ‘string’ or ‘1234’; set it to something like ‘Bob’.
 * Be a reflection of the keys return in every response for all users of the action. This means if there are custom fields that will be returned for some users and not others, please do not include these key:values in the sample data.
 
-### 5.6 Output Fields
+### 5.6 Output fields
 [Output Fields](https://platform.zapier.com/docs/faq#output) add user-friendly labels to your API’s response data to facilitate mapping fields during Zap setup for users. By default, Zapier will try to make friendly version of your API’s response, capitalizing words, and replacing underscores with spaces, but they an also be customized. Add a custom output field label when:
 
 * a field is abbreviated. For example, ‘LTV’ should be labeled ‘Lifetime Value’.
@@ -338,18 +340,18 @@ The ‘Test this Step’ step on actions sends a real request on behalf of the c
 * a field is represented by an ID.
 * in general, it is not instantly clear what the field or value represents.
 
-### 5.7 Create or Update Functionality
+### 5.7 Create or update functionality
 If your integration must have a ‘Create-or-Update’ functionality, implement a ‘Find-or-Create Search’ with an ‘Update’ action versus a ‘Search’ with a ‘Create-or-Update’ action or a standalone ‘Create-or-Update’ action.
 
-### 5.8 Delete Actions
+### 5.8 Delete actions
 Avoid delete actions which make it easy for users to accidentally delete data they didn’t intend to remove. Instead, offer less permanent actions such as options to deactivate, unsubscribe, or tag a user in a certain way (where users could then easily delete those items from inside your product).
 
 ## 6. Searches
 
-### 6.1 Important Searches
+### 6.1 Important searches
 We allow integrations to set a maximum of three searches as ‘Important’ via the [Visibility Option](https://platform.zapier.com/docs/actions#how-to-add-a-new-action-to-a-zapier-integration) in the Visual Builder or the basic [display schema](https://zapier.github.io/zapier-platform-schema/build/schema.html#basicdisplayschema) via the CLI. If you have three or less searches, generally you should set them all as ‘Important’.
 
-### 6.2 Find or Create
+### 6.2 Find or create
 Search actions can optionally create items if nothing is found in the search. If your integration has a ‘Create-or-Update’ action, please implement a ‘Find-or-Create Search’ with an ‘Update’ action versus a ‘Search’ with a ‘Create-or-Update’ action or a standalone ‘Create-or-Update’ action.
 
 ### 6.3 Copy
@@ -362,29 +364,29 @@ Additionally, each search must have:
 * a descriptive noun that reflects the object that will be returned. This should typically be one word and should always be in the singular form. The noun is used around the Zapier platform and will be pluralized automatically to complete various messages to users such as ‘No new <noun> found.‘
 * a concise description starting with a plural form of the verb, which typically is ‘Finds’, and ending in a period/fullstop. For example, a valid description for a ‘Find Lead’ search is ‘Finds a new lead.’ Please do not include the name of the platform nor capitalize the noun such a  ‘Finds a new Lead in XXX CRM.’
 
-### 6.4 Search Fields
+### 6.4 Search fields
 [Search fields](https://platform.zapier.com/docs/actions#2-build-action-input-form) should be named appropriately and include help text if their purpose is ambiguous.
 
-#### 6.4.1 ID Fields
+#### 6.4.1 ID fields
 * Users should never be expected to manually type or map an internal ID to a search field. Your integration should not have search fields labeled ‘XXX ID’. Generally, trigger and action steps of other integrations do not return internal IDs for your specific platform to be used in an action field from your Zapier integration. And if the user *is* using a trigger from your Zapier integration, the trigger should return all necessary information about the resource without the Zap needing a search step to retrieve additional, necessary information. Instead, provide search field options for more general information such as ‘name’, ‘email address’, ‘phone number’, ‘title’, etc. that is more readily-available from all triggers.
 
-#### 6.4.2 Help Text
+#### 6.4.2 Help text
 * Don't be redundant with help text, and only include it if you have something different to say from the field name such as the expected format of the value or additional instructions. Redundant help text teaches users not to read any help text at all, so important information can be missed.
 
-#### 6.4.3 Optional Search Fields
+#### 6.4.3 Optional search fields
 * If a search field is optional, confirm the request does not throw an error in a null case where the users does not select an option.
 
-#### 6.4.4 Field Types
+#### 6.4.4 Field types
 * Use the most appropriate [input field type](https://platform.zapier.com/docs/input-designer#zapier-input-field-types) for each of the input fields to show users what type of data to include — though do note Zapier does not validate the data to ensure users added the correct item for that field type. 
 * If the field can accept multiple values, use our built in [‘List’ property](https://zapier.github.io/zapier-platform-schema/build/schema.html#fieldschema) or ‘[Allow Multiples’](https://platform.zapier.com/docs/input-designer#allows-multiples) functionality rather than asking users to provide a comma-separated value in a text field.
 
 #### 6.4.5 Ordering
 * Put required search fields at the top of the form with optional fields towards the bottom by importance.
 
-### 6.5 Response Content
+### 6.5 Response content
 While create actions return a single object to Zapier; searches must return an array of objects. Each search must follow these guideline:
 
-#### 6.5.1 No Result
+#### 6.5.1 No result
 * Do not raise an error if there are no search results to return. If your API returns a 404 for search misses, use custom code to return an empty list.
 
 #### 6.5.2 Names
@@ -404,31 +406,31 @@ While create actions return a single object to Zapier; searches must return an a
 #### 6.5.5 Booleans
 * Set boolean values as `true` or `false`. Do not use `1` and `0` or alternative representations for boolean values.
 
-#### 6.5.6 Important Data
+#### 6.5.6 Important data
 * The response data should include important fields in the most usable format. For example, it helps to return both the ID and pretty name of resources, any important information about the resource such as contact information, and a link to the resource in the platform (ex: New Card in Trello, link to card).
 
-#### 6.5.7 Unnecessary/Excess Data
+#### 6.5.7 Unnecessary/excess data
 * Remove unnecessary fields that may seem confusing or add noise to users’ Zap setup process from your API call’s custom code. For example, if the response content includes information about the request itself and the input fields provided, please remove those fields from the returned response.
 
-### 6.6 Sample Data
+### 6.6 Sample data
 Each search requires [sample data](https://platform.zapier.com/docs/faq#output) for instances where no result is returned during Zap setup. This could be because the API is temporarily down, or because no result is returned for the specific search the user tests. The sample data must:
 
 * Only represent one record, and not the entire return from the request if there are multiple records returned as a set. For example, {"key": "value"} instead of [{"key": "value"}, {"key": "value2"}, ... ]. 
 * Use representative data in the expected format the values will be returned. For example, don’t set a ‘first name’ key to ‘string’ or ‘1234’; set it to something like ‘Bob’.
 * Be a reflection of the keys return in every response for all users of the search. This means if there are custom fields that will be returned for some users and not others, please do not include these key:values in the sample data.
 
-### 6.7 Output Fields
-[Output Fields](https://platform.zapier.com/docs/faq#output) add user-friendly labels to your API’s response data to facilitate mapping fields during Zap setup for users. By default, Zapier will try to make friendly version of your API’s response, capitalizing words, and replacing underscores with spaces, but they an also be customized. Add a custom output field label when:
+### 6.7 Output fields
+[Output fields](https://platform.zapier.com/docs/faq#output) add user-friendly labels to your API’s response data to facilitate mapping fields during Zap setup for users. By default, Zapier will try to make friendly version of your API’s response, capitalizing words, and replacing underscores with spaces, but they an also be customized. Add a custom output field label when:
 
 * a field is abbreviated. For example, ‘LTV’ should be labeled ‘Lifetime Value’.
 * a field has an ambiguous unit of measure. For example, ‘Duration’ should be labeled ‘Duration (in seconds)’.
 * a field is represented by an ID.
 * in general, it is not instantly clear what the field or value represents.
 
-## 7. Error Handling
+## 7. Error handling
 APIs are not always available. Users do not always provide valid data for requests. Build a defensive and resilient integration. Plan for 4xx and 5xx responses. Without proper handling, errors can have incomprehensible messages, technical error codes, or worse, go uncaught.
 
-### 7.1 General Errors
+### 7.1 General errors
 Use `ErrorException` in situations where users misconfigure their Zaps and need to take action. Typically, this will be for prettifying `4xx` responses and API’s that return errors as `200` with a payload that describes the error and any guidance on how to correct it, if possible.
 
 * Note if a Zap raises too many error messages it will be automatically turned off, so only throw these if the scenario is truly an error that needs to be fixed.
@@ -436,30 +438,22 @@ Use `ErrorException` in situations where users misconfigure their Zaps and need 
 * If the error calls out a specific field, surface that information to the user. ‘Title is not valid.’ is better than ‘Invalid Request.’
 * If the error provides details about why a field is invalid, surface that information to users. ‘Title is invalid. Please only use alphanumeric characters.’ is better than ‘Title is invalid.‘
 
-### 7.2 Halting Errors
+### 7.2 Halting errors
 Use `HaltedError` in situations where a required pre-condition is not met. For instance, in an action to add an email            address to a list where duplicates are not allowed, throw a `HaltedError` if the Zap attempted to add a duplicate. This          indicates failure, but is treated as a soft failure.
 
 * Note, unlike general errors, a Zap will never by turned off when this error is thrown even if it is raised more often than not.
 
-### 7.3 Stale Authentication Credentials
+### 7.3 Stale authentication credentials
 * For integrations requiring manual refresh of authorization on a regular basis, Zapier provides `ExpiredAuthError`, so the current operation is interrupted, the Zap is turned off (to prevent additional calls with expired credentials), and a predefined email is sent out informing the user to refresh the credentials.
 * For integrations using OAuth2 + refresh requests or Session Auth, use `RefreshAuthError`. This signals Zapier to refresh the credentials and retry the failed operation.
 
 ## 8. Code
 
-### 8.1 Environment Variables
+### 8.1 Environment variables
 Do not hard code credentials such as API Keys, Client IDs, Client Secrets, etc. into your integration. Use [environment variables](https://platform.zapier.com/docs/advanced#environment-variables)instead. 
 
 ### 8.2 Structure
 If you are using the [Zapier CLI](https://platform.zapier.com/cli_docs/docs) to build the integration, ensure files are logically broken out into respective directories and the code is easy to follow. We suggest putting triggers, actions, and searches each in their own directories.
 
-## After You Submit
 
-Once you’ve submitted your integration for publishing, you’re in the review process! Here are some things to keep in mind:
-
-* **Timing**: A member of the Zapier team will examine your integration as soon as possible. However, if your integration is complex or presents new issues, it may require greater scrutiny and consideration. And remember, if your integration is repeatedly rejected for the same guideline violation or you’ve attempted to manipulate the review process, review of your integration will take longer to complete.
-* **Status Updates**: A member of the Zapier team will be in touch as soon as possible to provide you feedback regarding your integration. In order to proceed to the next step of Publishing, you will need to respond to our feedback.
-* **Early Access**: Get listed on Zapier’s website and give users early access to your integration. We do our best to try and launch your integration into Early Access as quickly as possible. Learn more [here](https://platform.zapier.com/partners/lifecycle-planning#3-enable-early-access).
-* **Full Launch**: We keep an eye on your integration and may invite you to work with us on an official launch campaign to spread the word further. Learn more [here](https://platform.zapier.com/partners/lifecycle-planning#4-launch-your-zapier-integration).
-
-We're excited to have you as a Partner on Zapier! If you have any questions or concerns about our integration review guidelines, [email us](mailto:partners@zapier.com).
+If you have any questions or concerns about our integration review guidelines, contact Zapier via the [contact form](https://developer.zapier.com/contact).

--- a/docs/_partners/lifecycle-planning.md
+++ b/docs/_partners/lifecycle-planning.md
@@ -1,241 +1,146 @@
 ---
-title: How to Build and Publish a Zapier Integration
+title: Build your first public integration on Zapier
 order: 1
 layout: post-toc
 redirect_from: /partners/
 ---
-# How to Build and Publish a Zapier Integration
+# Build your first public integration on Zapier
 
-## 1. Plan Your Zapier Integration
+This guide gives an overview of the process to publishing a public integration. For public integrations, you'll join [Zapier's Partner Program](CHANGE URL) once your app has been successfully reviewed.
 
-No app can do everything on its own. The best apps are instead focused on their core features, then rely on integrations with dozens of other great apps to do the rest. That is what the Zapier platform enables. It brings the best of every app together.
+To get a picture of how your integration will show up on Zapier's website, you can browse the[ app directory](https://zapier.com/apps). It's a great idea to explore similar apps to see what triggers and actions they provide for building Zapier workflows, called Zaps.
 
-A Zapier integration connects your app to {{ site.partner_count }} of the best business and productivity apps so millions of Zapier users can add it to their workflows.
 
-If you haven't yet, please read [How Zapier Works](https://zapier.com/help/how-zapier-works/) and set up a few Zaps to get a sense of the user experience.
+## **Before you start**
 
-Then, before you start building, think through how your Zapier integration will work, and plan out what triggers and actions to build.
+Consider workflows your app will support, and what types of activities your users want to automate. Learn[ how Zapier works](https://zapier.com/help/how-zapier-works/) and set up a few Zaps to get a sense of the user experience.
 
-Building on the Zapier platform is different from other platforms. Instead of defining an entire app's end-to-end user experience, you're creating discrete triggers and actions .
+To design useful triggers and actions for your integration, consider how your users might need data from your app to run other parts of their business. Some of the most popular use cases for Zapier integrations include:
 
-However, it is similar in the sense that end user experience still matters **a lot**. Simply building triggers and actions from your public API endpoints isn't enough. You'll want to strongly consider workflows your app will support and what the user experience looks like while setting up a Zap with your app.
 
-The most successful integrations on Zapier only have two or three triggers and actions to start. You can always add more over time as users request them. If you need help figuring out what might be useful to your users, you can browse the [App Directory](https://zapier.com/apps) for similar apps and see what triggers and actions are supported.
 
-Start out by reading through our [Zapier Integration Planning guide](https://platform.zapier.com/partners/planning-guide), which includes the guidelines and considerations needed when building a Zapier integration:
+* Sending follow-up emails or messages
+* Copying data from a bill or invoice into another system
+* Updating contact records in multiple databases
+* Creating or updating records in a project management tool
 
-- [How to Brand Your Zapier Integration](https://platform.zapier.com/partners/planning-guide#how-to-brand-your-zapier-integration)
-- [How to Design Successful Zapier Authentication Flow](https://platform.zapier.com/partners/planning-guide#authentication)
-- [How to Design Successful Zapier Triggers](https://platform.zapier.com/partners/planning-guide#triggers)
-- [How to Design Successful Zapier Actions](https://platform.zapier.com/partners/planning-guide#actions)
-- [How to Design Successful Zapier Searches](https://platform.zapier.com/partners/planning-guide#searches)
+Learn more about how to[ approach use cases](https://platform.zapier.com/partners/integration-examples).
 
-### Learn From Popular Zapier Integration Categories
 
-Each type of app has its own special considerations on Zapier. Form apps, for example, need to return values from multiple choice questions, while CRMs need to manage a wide variety of related data. Check our category-specific guides to learn from these best practices before building your app's Zapier integration.
+## **Build your integration**
 
-- [Add a Form or Survey App to Zapier](https://platform.zapier.com/partners/integration-examples#form)
-- [Add a CRM or Contacts App to Zapier](https://platform.zapier.com/partners/integration-examples#crm)
-- [Add a Project Management App to Zapier](https://platform.zapier.com/partners/integration-examples#pm)
+Building a Zapier integration means identifying the right APIs for your triggers and actions, and designing an intuitive experience for your users to select and map the data they need.
 
-## 2. Build Your Integration
+There are two ways to build an integrations on Zapier’s Platform:
 
-Building a Zapier integration means keeping one eye on the technical bits and one eye on the user experience.
 
-Some of the best Zapier integrations are built when pairing an engineer and a product manager together. But anyone can build a Zapier integration, as long as you follow the guidelines in our [integration design guide](https://platform.zapier.com/partners/planning-guide) and [developer docs](https://platform.zapier.com/quickstart/introduction).
 
-There are two ways to build Zapier integrations on Zapier's Platform:our UI-based visual builder or CLI. The visual builder lets you create a Zapier integration in your browser without code—then can customize the integration with code if needed. The CLI, instead, lets you build integrations in your local development environment, collaborate with version control and CI tools, and push new versions of your integration from the command line. Both run on the same Zapier platform, so choose the tool that fits your workflow the best.
+* The Platform UI lets you create a Zapier integration in your browser without code using API endpoint URLs. You can also set any custom options your API may need, including custom URL params, HTTP headers, and request body items, using code mode.
+* Zapier Platform CLI lets you build a Zapier integration in your local development environment, collaborate with version control and CI tools, and push new versions of your integration from the command line.
 
-Learn how to use the Zapier Platform with our [visual builder Quick Start tutorial](https://platform.zapier.com/quickstart/introduction) or our [CLI Quick Start tutorial](https://zapier.com/developer/start/introduction). Then visit [zapier.com/app/developer](https://zapier.com/app/developer/) or enter `zapier init` in Terminal to build a new integration.
+Both of these tools run on the same Zapier platform, so choose the one that fits your workflow the best.
 
-### Test Your Integration
+Learn more about the difference between building with the[ Platform UI and the CLI](https://platform.zapier.com/docs/vs).
 
-While you're building your integration, it's best to test authentication, triggers, and actions as you add them to your app. In the Platform UI, you can test each step live in the editor as it's built. With both Platform UI and CLI, have a separate tab open in your browser to the user-facing [Zap editor](https://zapier.com/app/editor), then refresh anytime you add a new trigger or action to test it live immediately.
 
-> **Note:** You may have to refresh a few times for new triggers and actions to appear.
+## **Test your integration**
 
-After you're done building, invite users to try your integration before making it available to a wider audience.
+While you’re building your integration, you can test your API requests within the Integration Builder. For developers building on Zapier Platform CLI, you can write unit tests that run locally, in a CI tool like[ Travis](https://travis-ci.com/).
 
-#### Invite Others to Help Test Your Integration
+To get a sense of the user experience, it’s recommended to test your integration within the Zap editor.[ Create a new Zap](https://zapier.com/help/create/basics/create-zaps) that uses your integration’s triggers or actions to ensure they all work as expected. After you’re done building, invite users to try your integration before making it available to a wider audience.
 
-As you're getting close to finishing development, you’ll want others to try out your app using Zapier. You can invite co-workers or your users to provide feedback. Invitees must have a Zapier account, which they can create for free during the invite process.
+Learn more about testing your integration:
 
-You can invite people directly to your integration from Zapier's Platform UI, whether you built it in the Platform UI or CLI. Open Zapier's developer platform at [zapier.com/app/developer](https://zapier.com/app/developer), select your app, then click the _Sharing_ tab on the left. There, you can enter contacts' email addresses to invite them to your integration, or can copy a public invite link to share with those whom you want to test. The link will invite users to all versions of your app, while email invites allow you to select specific version(s) to share.
 
-![Invite screen](https://cdn.zapier.com/storage/photos/d7e6f91a029c9ae740f70e475c97081d.png)
 
-When users accept your invite or click the link, they'll see a page that explains that you have invited them to your app, covers some common questions about Zapier, and explains that you will support your app while in beta.
+* [Testing using Zapier Platform UI](https://platform.zapier.com/docs/testing)
+* [Testing using Zapier Platform CLI](https://platform.zapier.com/cli_docs/docs#testing)
 
-After accepting the invite, users land in the Zapier editor, where they are prompted to build a Zap with your product.
 
-It's a good idea to reach out to the users you invited and check in on their experience using your integration with Zapier so that you can identify any usability issues.
+## **4. Submit your integration for app review**
 
-#### Manage Your Integration Versions
+After you've confirmed your integration is working, you're almost ready to publish your app. To publish your integration, you need to submit your app for review.  
 
-As you work on your integration, start getting feedback from testers, and eventually release it to the public, you will want to add and change things over time. Zapier's Platform UI and CLI both support versioning to make minor or major versions of your integration. Each version is kept separate, so you can make changes to your integration without affecting other users.
+Before submitting your integration, review[ Zapier’s integration review guidelines](https://platform.zapier.com/partners/integration-review-guidelines) to speed up the app review process.
 
-Find out more in our _[How to Maintain Your Zapier Integration](https://platform.zapier.com/partners/feature-requests-bugs)_ guide.
+To submit your integration for app review:
 
-## 3. Publish Your Integration to the App Directory
 
-Now that you're finished developing and testing your Zapier integration, it's time to share it with the world! When you publish your integration, your product will get a dedicated page in [Zapier's App Directory](https://zapier.com/apps). Just follow these steps:
 
-> If you’re not seeing the publishing features, check your [integration settings are set to public](https://platform.zapier.com/docs/start#edit-your-zapier-integration-info).
+1. [Log into the Platform UI](https://zapier.com/app/developer)
+2. Select your **integration**.
+3. In _Integration Home_, click **Publish.**
+4. You’ll need to complete our online form.
+5. Click **Submit for Review**.
 
-### **1. Ensure your integration follows the Zapier Integration Development Guide**
+After you’ve submitted your integration for review, one of our developers will reach out to you in 1 week or less. Zapier will update your:
 
-The [Integration Development Guide](https://platform.zapier.com/partners/planning-guide) is written with the user in mind, ensuring a consistent experience across Zapier. Hundreds of companies have launched Zapier integrations and the Integration Development Guide is a list of best practices learned, so your users have the best experience with your Zapier integration.
 
-We recommend your Zapier integration have no more than 5 of each (trigger, action, or search) at first; we suggest starting with your most popular 2-3 use cases.
 
-### **2. Have at least 1 live Zap for each of your integration's visible Triggers, Actions, and Searches**
+* App version to **Pending**.
+* App status will remain as **Private**.
 
-Clone your integration and place it into invite-only mode. Doing so provides you a link to share this instance of your Zapier integration with prospective users.
 
-The intention of this step is to ensure any show-stopping bugs are worked out and verify existing user demand. Towards this end, your users should be non-QA emails and external or outside of your company.
+## **Beta phase**
 
-### **3. Prepare your team to support and maintain your integration**
+When your integration is approved, Zapier will update your:
 
-Zapier's support team serves as frontline support for your Zapier integration. As users encounter bugs or think of new features they’d like within the integration, some reach out to the Zapier support team. Those requests are logged in Zapier’s issue tracker, which you can see from the Bug & Feature Requests page of the integration’s developer platform. If you prefer syncing and managing issues from your own issue-tracking tools (such as Jira or Trello), you can create Zaps to do so using [Zapier Issue Manager](https://platform.zapier.com/partners/zim). We expect your team to promptly reply to those requests and to maintain your integration.
 
-### **4. Submit your integration for review by the Zapier team**
 
-Read our [App Review Guidelines](https://platform.zapier.com/partners/integration-review-guidelines) to help you better prepare your integration before submitting it for review.
+* App status to **Public**.
+* App version will update to **Beta**.
+* Integration will be added to[ Zapier’s app directory](https://zapier.com/apps) with a Beta tag.
 
-Then, navigate to the Publishing page for your app, fill out the form, and click _Submit for Review_.
+Your integration will remain in beta for 90 days.
 
-![Publishing integration page](https://cdn.zappy.app/5717927f617ec65928b00b23459365fe.png)
+Whilst in public beta, we recommend completing these tasks to improve your integration:
 
-Expect to hear from us within a week.
 
-<a id="early"></a>
+### **Add help docs to Zapier’s Help Center**
 
-### Your App is Now a Part of the Zapier Platform!
+The Zapier team provide frontline support for your integration, and in order to provide the best experience for your users, we also host help documentation about your integration in the[ Zapier Help Center](https://help.zapier.com/hc/en-us). Help our Technical Writing team create accurate documentation by filling out[ this form](https://eu.jotform.com/form/202233475923352). We can also include link out to documentation on your site to help customers find the information they are looking for.
 
-Your app will be listed with a dedicated page in [Zapier's App Directory](https://zapier.com/apps). All Zapier users can discover your app and start building Zaps with your integration. Your new integration will feature a Beta tag when it's first published. At this point you'll have access to build Zap Templates, which are the best way to help new users discover specific useful things they can do with your integration.
+Once submitted, it takes roughly 2 weeks to get help docs published in the Help Center.
 
-### What's the Next Step?
 
-As your integration continues to accumulate users, our team will watch the growth of your integration. Once your integration [reaches 50 users](https://zapier.com/developer/documentation/v2/app-lifecycle/#1-wait-for-an-invite-from-the-zapier-team), our partner team will reach out and talk about next steps working with Zapier to grow your business and share Zapier with your users.
+> **Tip:** As you maintain your integration, you can use the same form to submit updates at any time to the Technical Writing team.
 
-## 4. Launch with the Partner Program
 
-We may invite your company to officially launch your Zapier integration and join the [Zapier Integration Partner Program](https://zapier.com/platform/partner-program). Once you launch, you will automatically join the free **Zapier Integration Partner Program** and can access the program's [many co-marketing benefits](https://zapier.com/platform/partner-program) including:
+### **Create Zap templates**
 
-- A shoutout about the launch of your integration in our [updates blog post](https://zapier.com/blog/all-articles/product-news/)
-- Access to your [integration health data](https://platform.zapier.com/partners/feature-requests-bugs#how-to-monitor-integration-insights)
-- A dedicated page in [Zapier’s App Directory](https://zapier.com/apps)
-- Exposure within Zapier's product and on the sites of Zapier's {{ site.partner_count }} integration partners
+As soon as your app is published and in beta you can begin creating and sharing[ Zap Templates](https://zapier.com/developer/zap-templates). Zap Templates are readymade integrations or Zaps with the apps and core fields pre-selected. In a few clicks, they help people discover a use case, connect apps, and turn on the Zap.
 
-Here are the steps to take to officially launch and join the program:
+Learn more about creating[ Zap templates](https://platform.zapier.com/partners/zap-templates).
 
-<a id="wait"></a>
 
-### **1. Build, test, and publish your Beta integration**
+### **Embed Zapier in your product or website**
 
-See previous section on building and publishing a new integration.
+The best way to ensure users are able to discover your Zapier integration is to surface your integration where users are looking at it. By embedding Zapier in your product, you can create end-to-end user experience, helping your customers discover available integrations within your product without having to leave your app.
 
-As mentioned above, you’ll need to complete the following tasks before the Beta tag is removed from your app listing:
+Learn more about[ embedding Zapier.](https://platform.zapier.com/embed/overview)
 
-- Create at least 10 Zap Templates
-- Submit Help Docs
-- Reach 50 users OR embed your Zap Templates into your own product
 
-Remember, once you fulfill the criteria above, you’ll automatically join the free Zapier Partner Program to earn co-marketing benefits as your integration grows.
+### **Grow active usage**
 
-Up next, we’ll dive into these requirements more.
+During the beta stage of your integration, it's important to actively work on growing the usage of your app. By encouraging more people to use your integration, you'll be able to gather valuable insights and feedback early on, which will help you optimize it further.
 
-### Create 10 Zap Templates
+Learn more strategy[ tips to improve your integration](https://platform.zapier.com/partners/partner-faq).
 
-***Estimated time to complete:*** _1-2 hours_
 
-***Who to involve:*** _Your product or marketing team_
+### **Manage bugs and feature requests**
 
-As soon as your app is published and in beta you can begin creating and sharing [Zap Templates](https://zapier.com/developer/zap-templates). Zap Templates are readymade integrations or Zaps with the apps and core fields pre-selected. In a few clicks, they help people discover a use case, connect apps, and turn on the Zap. We’ll look for a least 10 of these in place before an official partnership launch.
+With the Zapier Issue Manager, you have the ability to conveniently address bugs and new feature requests within your preferred issue-tracking tool. Regularly reviewing and taking action on these items will greatly contribute to enhancing the overall health score of your integration.
 
-### Help our team create Help Docs on Zapier.com
+Learn more about[ Zapier Issue Manager](https://platform.zapier.com/partners/zim).
 
-***Estimated time to complete:*** _5 minutes_
 
-***Who to involve:*** _Your product or marketing team_
+## **Public phase**
 
-The Zapier team provides frontline support for your integration and, in order to provide the best experience for your users, we also host help documentation about your integration on our site. Help our support team create accurate documentation by filling out [this form](https://eu.jotform.com/form/202233475923352).
+After 90 days in public beta, your integration will become public:
 
-### Reach 50 users
 
-While your integration is in beta, we'll monitor how it's performing. When your integration reaches 50 users, our team will get in touch to invite you to start the official partner program launch process.
 
-<a id="beta"></a>
+* Your app status will be updated to public, and the beta tag will be removed.
+* You’re added to our[ Partner Program](https://coda.io/d/_d-clruQiSri/_susbo#_luCcs), where you can earn marketing and support benefits.
 
-### Easily embed your Zapier integration into your product
-
-***Estimated time to complete:*** _5-10 minutes for an engineering or technical resource_
-
-***Who to involve:*** _Your product and development team_
-
-The best way to ensure users are able to discover how to connect your app to {{ site.partner_count }} other apps is to surface your integration where your users are looking for it. Using Zapier’s embedding technology, you can present your most popular Zap Templates to your users in your app’s UI, help docs, FAQs, blog posts, and more.
-
-There are lots of ways to embed Zapier workflows into your product. Jump into the Embed section of your developer dashboard for an interactive sandbox, but the high-level breakdown is below.
-
-> **Tip:** Looking for buy-in from your team on embedding Zapier into your product? Share examples and how it’ll make your customers happier, more loyal, and more successful with [this resource](https://zapier.com/partner/solutions). 
-
-**Option 1**
-The Full Zapier Experience and embedding Zap Templates: Embed quickly by copying and pasting a few simple lines of code
-
-Use our [plug and play solutions](https://zapier.com/partner/solutions/plug-and-play) to generate your own Full Zapier Experience or embed Zap Templates that features your app. This small snippet of code allows you to quickly and easily embed the Full Zapier Experience and/or your Zap Templates on your site and in your product.
-
-Here is an example of what embedded Zap Templates look like for MailChimp:
-
-<zapier-zap-templates theme="light" apps="mailchimp" create-without-template="hide" limit="5" use-this-zap="show"></zapier-zap-templates>
-<br />
-
-**Option 2**
-The Partner API: Embed in a customized way to fit the style of your product
-
-Our [Partner API](https://platform.zapier.com/partners/zap-templates#embed-zapier-into-your-app-with-zapier-partner-api) gives you total control over the look and feel of the Zapier experience inside your app.
-
-Here is an example of how our partner Unbounce implemented the Partner API inside their product:
-
-![](https://cdn.zapier.com/storage/photos/9e769e34030c2bbcf2fb80b827d69c22.png)
-
-### Create help documentation for the integration on your site
-
-***Estimated time to complete:*** _1 day_
-
-***Who to involve:*** _Your support or marketing team_
-
-Make sure your users of your Zapier integration can get their questions answered easily. Create help documentation on your site like our partner Autopilot did:
-
-![](https://cdn.zapier.com/storage/photos/90186e0afa54eab0817ae1f66488d380.gif)
-
-We've put together [this template](https://docs.google.com/document/d/1eg3CaU9ytf5QH38FuaxAyQgmFN2HYZFbBN7E3l9kZZg/edit) to help you get your page up quickly.
-
-### **2. Create a marketing campaign for your integration’s full launch**
-
-***Estimated time to complete:*** _1-2 weeks_
-
-***Who to involve:*** _Your marketing team_
-
-After you've passed the Beta phase, work with your marketing team to create a launch campaign to let your users know that they can now connect your product to {{ site.partner_count }} web apps. Marketing campaigns help you get more users on your integration right away, so you can rise the ranks of the Zapier Partner Program more quickly.
-
-Here's some inspiration from some of our most successful partners:
-
-- Write a blog post about the integration like [Evernote](https://evernote.com/blog/speed-up-evernote-workflows-with-zapier/) did
-- Send an [email](https://cdn.zapier.com/storage/photos/c760446e7cd5a1448ba66aeb6b7b002a.png) to your users to announce the integration like Wunderlist did
-- Send an [in-app announcement](https://cdn.zapier.com/storage/photos/6ddd0d8aeb90f73590673cfa569c192f.png) like Feedly did
-- Promote the integration on social media like [Hootsuite](https://cdn.zapier.com/storage/photos/71c1d98949f7063bbbd210de211f0e47.png) did
-- Feature your Zapier integration in your product's onboarding sequence like [Base CRM](https://cdn.zapier.com/storage/photos/9b1c3ac4d870456e5f4ceedc85159878.png) does
-- Add your Zapier integration to your website's [integration directory](https://cdn.zapier.com/storage/photos/edaae7a3799ad14ecc970daa0ea49b8f.gif) like Zoho Connect
-
-Make sure to check out [Zapier's brand guidelines](https://zapier.com/resources/partner-marketing) as you're planning!
-
-## 5. Get Zapier Integration Support
-
-![](https://cdn.zapier.com/storage/photos/352d5dea5b77da6d6e0c930c67d90be4.png)
-
-Once you've launched your Zapier integration in the partner program, you're enrolled in the [Zapier Partner Program](https://zapier.com/platform/partner-program) and are eligible for a variety of benefits. Congrats! You'll receive monthly emails from us about how your integration is doing, plus updates on where you stand and what benefits you're eligible for.
-
-- Have questions about how the Zapier Partner Program works? [Check out our FAQ page](https://platform.zapier.com/partners/partner-faq#zapier-partner-program-faqs).
-- Curious about how to increase usage and move up levels in the program? Here are some [tips on getting more users](https://platform.zapier.com/partners/partner-faq), according to top Zapier partners.
-
-_Have any other questions about the Partner Program? Please [email us](mailto:partners@zapier.com)._
+Learn more about[ maintaining your Zapier integration](https://platform.zapier.com/partners/feature-requests-bugs).

--- a/docs/_partners/partner-faq.md
+++ b/docs/_partners/partner-faq.md
@@ -1,11 +1,11 @@
 ---
-title: Zapier Partner Program Tips and FAQs
+title: Zapier Partner Program tips
 order: 7
 layout: post-toc
 redirect_from: /partners/
 ---
 
-# Zapier Partner Program Tips and FAQs
+# Zapier Partner Program tips
 
 With {{ site.partner_count }} integration partners on Zapier, we have the inside scoop on the activities that can skyrocket your growth and earn you more [benefits from the Partner Program](https://zapier.com/platform/partner-program). Steal these 10 tried-and-true tactics from our top partners and you'll be on your way to the Platinum level.
 
@@ -67,7 +67,7 @@ As your product evolves, your integration should, too. An up-to-date, bug-free i
 > **Do this yourself by:**
 
 > + Making an update your users are asking for. Review feature requests by logging in to [the dashboard](https://zapier.com/developer/builder) with your developer credentials.
-> + Creating new [Zap Templates](https://zapier.com/developer/shared-zaps/create/) to inspire use cases.
+> + Creating new [Zap templates](https://zapier.com/developer/shared-zaps/create/) to inspire use cases.
 > + Promoting the new Zapier features to your users in a blog post or email.
 
 ## Tip 6: Power up your app marketplace with Zapier-enabled listings
@@ -129,63 +129,3 @@ Zero in on the users most likely to adopt automation into their everyday work. W
 > + Identifying key actions your users that can be boosted with automation.
 > + Using your marketing automation to message users who take that action.
 
-***
-
-# Zapier Partner Program FAQs
-
-> - [What is the Zapier Partner Program?](#what-is-the-zapier-partner-program)
-> - [I'm already a Zapier partner. How do I know what level I'm in?](#im-already-a-zapier-partner-how-do-i-know-what-level-im-in)
-> - [How do I become a part of the Zapier Partner Program?](#how-do-i-become-a-part-of-the-zapier-partner-program)
-> - [How are the program's levels calculated? How often can I change levels in the program? Can I move down levels?](#how-are-the-programs-levels-calculated-how-often-can-i-change-levels-in-the-program-can-i-move-down-levels)
-> - [How is my integration's number of active users calculated? How can I increase it?](#how-is-my-integrations-number-of-active-users-calculated-how-can-i-increase-it)
-> - [How is my integration's health score calculated? How can I improve it?](#how-is-my-integrations-health-score-calculated-how-can-i-improve-it)
-> - [How can I access my integration and see my Partner Program metrics outside of your monthly emails?](#how-can-i-access-my-integration-and-see-my-partner-program-metrics-outside-of-your-monthly-emails)
-> - [Is my level in the Partner Program visible to others?](#is-my-level-in-the-partner-program-visible-to-others)
-
-## What is the Zapier Partner Program?
-
-The [Zapier Partner Program](https://zapier.com/platform/partner-program) is a program for Zapier's [{{ site.partner_count }} integration partners](https://zapier.com/apps). It is designed to give all partners a clear path to success for their integrations and reward them with benefits along the way.
-
-## I'm already a Zapier partner. How do I know what level I'm in?
-
-Find out where you stand by [signing up](https://zapier.typeform.com/to/ItvJSG) for our monthly partner newsletter or [logging in](https://zapier.com/developer/builder/) with your developer credentials.
-
-## How do I become a part of the Zapier Partner Program?
-
-You're eligible for the Zapier Partner Program once you build and [launch your Zapier integration](https://zapier.com/developer/documentation/v2/lifecycle-activation/#process).
-
-## How are the program's levels calculated? How often can I change levels in the program? Can I move down levels?
-
-Your level in the Zapier Partner Program is determined by your integration's number of active users and integration health score.
-
-![](https://cdn.zapier.com/storage/photos/f050f5e3c39829a08a016c42ef5c491b.png)
-
-Levels are evaluated on a fixed quarterly basis: at the beginning of January, April, July, and October.
-
-You can change levels every quarter. You cannot change levels in the middle of a quarter. If at the beginning of a quarter, you don't meet all requirements of a level, you will move down to a level that you do meet all the requirements of.
-
-## How is my integration's number of active users calculated? How can I increase it?
-
-This metric looks at how many people are actively using your Zapier integration this quarter. Since this number accumulates over the quarter, it is normal to see a drop at the beginning of each quarter compared to the end of last quarter.
-
-To increase usage of your Zapier integration, try out [these 10 tactics](https://zapier.com/developer/documentation/v2/partner-program-tips/).
-
-## How is my integration's health score calculated? How can I improve it?
-
-We calculate the integration health score by looking at how many feature requests and bugs have been reported for your integration and how responsive your team is to those reports. Some feature requests and bugs impact your score more than others. For example, a feature request with 100 users voting for it will impact your health score more than a feature request with 1 vote.
-
-As a reminder, our goal for all integrations is for them to maintain a "healthy" health score. No level of the program requires an "exceptional" health score (although it's certainly great if your integration does go above and beyond!).
-
-![](https://cdn.zapier.com/storage/photos/1e71ec2a31c0cdecf7880f4ac1f4915d.gif)
-
-To improve your health score, [respond to](https://zapier.com/developer/documentation/v2/feature-requests-bugs/) and resolve your outstanding feature requests and bugs by logging into the [developer platform](https://zapier.com/developer/builder/) and navigating to the "Issues" tab.
-
-## How can I access my integration and see my Partner Program metrics outside of your monthly emails?
-
-Use your developer's credentials to log into the [developer platform](https://zapier.com/developer/builder/). If you can't access it, please [email us](mailto:partners@zapier.com) and we can help!
-
-## Is my level in the Partner Program visible to others?
-
-Zapier won't externally share your level in the Partner Program with anyone, including other partners and Zapier users. But if you'd like to, you're welcome to share your level in the program with your users.
-
-**If your questions weren't answered above, feel free to [email us](mailto:partners@zapier.com).**

--- a/docs/_partners/partner-program.md
+++ b/docs/_partners/partner-program.md
@@ -1,0 +1,64 @@
+---
+title: About the Partner Program
+order: 2
+layout: post-toc
+redirect_from: /partners/
+---
+# About the Partner Program
+
+> **The Partner Program is only eligible for integrations with public intent.**
+
+The [Zapier Partner Program](https://zapier.com/platform/partner-program) is a program for Zapier’s [5,000+ integration partners](https://zapier.com/apps). It is designed to give all partners a clear path to success for their integrations and reward them with benefits along the way.
+
+As you get more users and maintain a healthy integration, and you get access more benefits across our tiered system. We have 4 levels:
+
+
+* Bronze
+* Silver
+* Gold
+* Platinum
+
+Learn more about what[ benefits are available in each level](https://zapier.com/platform/partner-program).
+
+
+## How levels are calculated
+
+Your level in the Zapier Partner Program is determined by your integration’s number of active users and integration health score.
+
+![Zapier Partner Program levels](https://cdn.zapier.com/storage/photos/f050f5e3c39829a08a016c42ef5c491b.png)
+
+Levels are evaluated on a fixed quarterly basis: at the beginning of January, April, July, and October.
+
+You can change levels every quarter. You cannot change levels in the middle of a quarter. If at the beginning of a quarter, you don’t meet all requirements of a level, you will move down to a level that you do meet all the requirements of.
+
+
+Zapier won’t externally share your level in the Partner Program with anyone, including other partners and Zapier users. But if you’d like to, you’re welcome to share your level in the program with your users.
+
+### Active users
+
+The active users metric looks at how many people are actively using your Zapier integration this quarter. Since this number accumulates over the quarter, it is normal to see a drop at the beginning of each quarter compared to the end of last quarter.
+
+To increase usage of your Zapier integration, try out [these 10 tactics](https://zapier.com/developer/documentation/v2/partner-program-tips/).
+
+
+### Integration health score
+
+ We calculate the integration health score by looking at how many feature requests and bugs have been reported for your integration and how responsive your team is to those reports. Some feature requests and bugs impact your score more than others. For example, a feature request with 100 users voting for it will impact your health score more than a feature request with 1 vote.
+
+As a reminder, our goal for all integrations is for them to maintain a “healthy” health score. No level of the program requires an “exceptional” health score (although it’s certainly great if your integration does go above and beyond!).
+
+![Zapier Partner Program Integration Health Score](https://cdn.zapier.com/storage/photos/1e71ec2a31c0cdecf7880f4ac1f4915d.gif)
+
+To improve your health score, [respond to](https://zapier.com/developer/documentation/v2/feature-requests-bugs/) and resolve your outstanding [feature requests and bugs](https://platform.zapier.com/partners/feature-requests-bugs#how-to-monitor-feature-requests-and-bugs).
+
+
+## View Partner Program metrics
+
+You can view Partner Program metrics in two ways:
+
+* **Partner newsletter**: Opt in to our [partner newsletter](https://zapier.com/developer/partner-settings/email/), and we’ll email you monthly updates.
+* **Partner Program dashboard**: Log into the [developer platform](https://zapier.com/developer/builder/) with your developer’s credentials. In the left side bar, click **Partner Program** to view your metrics.
+
+ If you have any questions about the Partner Program, reach out to our Partner Support team via our [contact form](https://developer.zapier.com/contact). 
+
+ 

--- a/docs/_partners/planning-guide.md
+++ b/docs/_partners/planning-guide.md
@@ -1,11 +1,11 @@
 ---
-title: Zapier Integration Branding and Design Guidelines
-order: 2
+title: Zapier integration branding and design guidelines
+order: 4
 layout: post-toc
 redirect_from: /partners/
 ---
 
-# Zapier Integration Branding and Design Guidelines
+# Zapier integration branding and design guidelines
 
 No app can do everything on its own. The best apps are instead focused on their core features, then rely on integrations with dozens of other great apps to do the rest. That is what the Zapier platform enables. It brings the best of every app together.
 
@@ -13,14 +13,14 @@ A Zapier integration connects your app to {{ site.partner_count }} of the best b
 
 Here are the core things to keep in mind to build a great Zapier integration.
 
-## How to Brand Your Zapier Integration
+## How to brand Your Zapier integration
 
-![Zapier App Directory](https://cdn.zappy.app/a0f7ce40c90b488c9ddf04b65db1c58b.png)
-_The Zapier App Directory is the best way to find new apps to add to your workflows_
+![Zapier app directory](https://cdn.zappy.app/a0f7ce40c90b488c9ddf04b65db1c58b.png)
+_The Zapier app directory is the best way to find new apps to add to your workflows_
 
 Your customers already recognize your app name and logo, and they’ll look for it inside Zapier. Zapier users who have never used your app may discover it through Zapier when looking for a new tool. That makes consistent branding a core part of a successful Zapier integration.
 
-The search for new apps and integrations starts at the [Zapier App Directory](https://zapier.com/apps/). Apps are ranked by popularity and category, with a search box to filter through the list.
+The search for new apps and integrations starts at the [Zapier app directory](https://zapier.com/apps/). Apps are ranked by popularity and category, with a search box to filter through the list.
 
 ![Zapier app directory pages](https://cdn.zappy.app/06ab4121b4b18d05816e1293aeb185a5.png)
 _App Directory listings help users discover new ways to connect apps_
@@ -39,7 +39,7 @@ Then, inside the core Zapier app, users will again see your app name and logo in
 
 When you create a Zapier integration, you’ll be asked to add your app’s name, logo, description, category, along with your brand color when the integration is launched publicly. Follow these guidelines to effectively brand your app on Zapier:
 
-### App Name
+### App name
 
 Use the actual, unique name of your app with the same capitalization your company uses in your core branding. Trademark/copyright identifiers such as a TM suffix aren't allowed in the app name, though they can be added to the [Description](https://platform.zapier.com/partners/planning-guide#app-description-copy).
 
@@ -50,7 +50,7 @@ Do not add adjectives or phrases to your app name, and only include your company
 - `Evernote`, not `Evernote Note Taking App` or `EverNote`
 - `Google Sheets`, not `Sheets` or `Google Spreadsheets`
 
-### App Logo
+### App logo
 
 Upload a square, transparent PNG format logo for your app at least 256x256px in size (please use a bigger version if you have one available). If your app has a solid, square background, round the corners 3% of the width and set the background as transparent. If your icon is not square, make a square transparent image and center your icon inside the transparent square.
 
@@ -66,7 +66,7 @@ Evernote's elephant icon is included in a transparent square rectangle.
 
 Todoist's icon includes transparent, rounded corners.
 
-### App Description Copy
+### App description copy
 
 Write a short description (up to 140 characters) of your app’s core features and use cases. Include your app’s name in the description, then explain what makes your app different and the reason one should use it. Use proper English and full sentences.
 
@@ -99,7 +99,7 @@ Do not use pure white (`#FFFFFF`) for either color, as overlaid text would be un
 
 Zapier uses the primary color as the background color in your app’s Zapier App Directory listing, and may additionally use it in the Zapier app dashboard, Zapier blog marketing materials, and other parts of Zapier’s app and content that promote your app’s integrations.
 
-## How to Design Successful Zapier Integrations
+## How to design successful Zapier integrations
 
 It starts with a Google search, perhaps, or a peek at Zapier's App Directory to find a new integration. Then the user makes a new Zap, either manually or from a Zap Template, and chooses your app. Then they connect their account with your app, set up the trigger or action they need for this workflow, and tell Zapier what data to copy from other apps to your app or vice versa.
 
@@ -132,15 +132,15 @@ Basic authentication, while acceptable, is the least appropriate authentication 
 
 Here are additional considerations when adding authentication to your integration:
 
-**Include Help Text**: If your authentication requires users to enter a domain name, API key, or other information that could be confusing, always include help text for those authentication input fields. Add links to your app in the help text with [Markdown](https://zapier.com/blog/beginner-ultimate-guide-markdown/).
+**Include help text**: If your authentication requires users to enter a domain name, API key, or other information that could be confusing, always include help text for those authentication input fields. Add links to your app in the help text with [Markdown](https://zapier.com/blog/beginner-ultimate-guide-markdown/).
 
-**Link to API Key (with API Key Authentication)**: If your authentication requires an API key, include a direct URL where users can obtain their API key from your app. If there is no direct link, include as clear of directions as possible to help users find the API key.
+**Link to API key (with API key authentication)**: If your authentication requires an API key, include a direct URL where users can obtain their API key from your app. If there is no direct link, include as clear of directions as possible to help users find the API key.
 
-**Use a Dedicated Endpoint for Testing**: Your Authentication Test API call should ping an endpoint such as `/me` or `/user` that tests if the authentication was successful but does not require additional input. This call should return a `2xx` error for invalid authentication. Do not use an API call that returns a `4xx` error for missing input data aside from authentication.
+**Use a dedicated endpoint for testing**: Your Authentication Test API call should ping an endpoint such as `/me` or `/user` that tests if the authentication was successful but does not require additional input. This call should return a `2xx` error for invalid authentication. Do not use an API call that returns a `4xx` error for missing input data aside from authentication.
 
-**Customize Your Connection Label**: Zapier includes the app name, integration version, and a number to help identify each connected account, so users can add multiple accounts of one app to Zapier. When building your integration's authentication, be sure to customize your connection label to include a username, email address, or other data aside from passwords and API keys entered during authentication or returned by your test trigger. Learn how in Zapier's [Visual Builder](https://platform.zapier.com/docs/auth#how-to-add-a-connection-label-to-authenticated-accounts) and [Platform CLI](https://github.com/zapier/zapier-platform/blob/master/packages/cli/README.md#authentication) docs.
+**Customize your connection label**: Zapier includes the app name, integration version, and a number to help identify each connected account, so users can add multiple accounts of one app to Zapier. When building your integration's authentication, be sure to customize your connection label to include a username, email address, or other data aside from passwords and API keys entered during authentication or returned by your test trigger. Learn how in Zapier's [Visual Builder](https://platform.zapier.com/docs/auth#how-to-add-a-connection-label-to-authenticated-accounts) and [Platform CLI](https://github.com/zapier/zapier-platform/blob/master/packages/cli/README.md#authentication) docs.
 
-## Zap Steps
+## Zap steps
 
 Every Zapier integration includes at least one trigger or action, and ideally will include several triggers, actions, and searches to let users do as much with the app through Zapier as possible. Triggers, actions, and searches—together called _Zap Steps_—all have their own unique considerations, but also have some common things to keep in mind.
 
@@ -185,9 +185,9 @@ Or imagine a “New Email” trigger in an email app. Users may want to watch fo
 
 **Watch for specific updates**. Don't include a generic "Item Updated" trigger. Think instead about the scenario where users would want to watch for updated items. They may want to watch for deal status changes in a CRM, or email address changes from contacts. Include filters so users can watch for the specific updates that are important to their work.
 
-**Use REST Hooks whenever possible**. Zaps with [REST hook](http://resthooks.org) triggers run automatically when new data is available, which matches users' expectations from automation. Polling triggers, instead, run `GET` calls every 1 to 15 minutes, depending on the user's Zapier plan, and static webhooks are not supported (as users could instead use Zapier's built-in [Webhooks app](https://zapier.com/apps/webhook/integrations)).
+**Use REST hooks whenever possible**. Zaps with REST hook triggers run automatically when new data is available, which matches users' expectations from automation. Polling triggers, instead, run `GET` calls every 1 to 15 minutes, depending on the user's Zapier plan, and static webhooks are not supported (as users could instead use Zapier's built-in [Webhooks app](https://zapier.com/apps/webhook/integrations)).
 
-**Only include Trigger input fields where necessary**. Many triggers need no fields, as they simply watch for new or updated items without any additional input from users. If your trigger would return a large amount of data to Zapier and cause the Zap to run too often, include input fields to let users filter and only run the Zap on the data they want.
+**Only include trigger input fields where necessary**. Many triggers need no fields, as they simply watch for new or updated items without any additional input from users. If your trigger would return a large amount of data to Zapier and cause the Zap to run too often, include input fields to let users filter and only run the Zap on the data they want.
 
 **Use smart defaults for input fields**. If your API requires a trigger field, use the default value where possible. For example, Dropbox' **New File** trigger watches for new files in the root directory by default. That helps users successfully set up Zaps even if they don't customize the input field.
 
@@ -206,9 +206,9 @@ Triggers are focused on data that has been added in your app. Actions are focuse
 
 **Focus on popular use cases**. Think about what users would want to automatically create in your app, and build actions for those specific items. Think about everything they would need to create in a workflow—would they need to create folders along with new files? Would they need to add a customer for a new order? That will help you find other actions that may need to be added.
 
-**Do not add Delete actions**. Deleting data automatically can let users accidentally delete data they didn't intend to delete. Instead, offer less permanent actions such as options to deactivate, unsubscribe, or tag a user in a certain way (where users could then easily delete those items from inside your app).
+**Do not add delete actions**. Deleting data automatically can let users accidentally delete data they didn't intend to delete. Instead, offer less permanent actions such as options to deactivate, unsubscribe, or tag a user in a certain way (where users could then easily delete those items from inside your app).
 
-**Only add Update actions for clear use cases**. Updating items with detailed fields such as contact details are easy, as users can simply add the updated data via Zapier. Updating a longer, single item such as a note or document is harder or impossible to implement, and thus should not be used in a Zapier integration. Update actions should be separate from create actions.
+**Only add update actions for clear use cases**. Updating items with detailed fields such as contact details are easy, as users can simply add the updated data via Zapier. Updating a longer, single item such as a note or document is harder or impossible to implement, and thus should not be used in a Zapier integration. Update actions should be separate from create actions.
 
 **Actions may create multiple items if needed**, using the same data, though you will likely need to customize the API call code to create multiple items at once. Only do this for linked items, such as if an app stores customers and customer addresses separately.  If the multiple items that need to be created are top-level, complex items in your app, they should be separate actions within Zapier. You can then link the two with a drop-down menu in the action to select the paired item, add a search action for users to find the specific item they need, and then let them match the items with the [_Use a Custom Value_ option](https://zapier.com/help/create/customize/add-custom-values-to-dropdown-menu-fields-in-zaps) in Zapier.
 
@@ -228,9 +228,9 @@ Searches may enable more advanced actions, where users can find an item then use
 
 ![Search or Create in Zapier](https://cdn.zappy.app/ebb86788d99f03f117cc7504e894d11b.png)
 
-**Add matching Create actions where possible**, then enable the _Search or Create_ functionality in your Search action so Zapier can let users create the item if Zapier doesn't find it. That lets users keep from adding duplicate data to your app, and lets their Zap continue to work even if the search comes back without data.
+**Add matching create actions where possible**, then enable the _Search or Create_ functionality in your Search action so Zapier can let users create the item if Zapier doesn't find it. That lets users keep from adding duplicate data to your app, and lets their Zap continue to work even if the search comes back without data.
 
-## Output Data
+## Output data
 
 Each Zap step must return data to Zapier to use in subsequent steps. By default, the output data is the direct response from your API—but in some cases, you may need to customize the response data to make it work well with Zapier. Here are general principles for output data from your Zap steps:
 

--- a/docs/_partners/trusted-developers.md
+++ b/docs/_partners/trusted-developers.md
@@ -1,16 +1,16 @@
 ---
-title: Zapier Trusted App Developers
-order: 10
+title: Zapier trusted app developers
+order: 11
 layout: post-toc
 redirect_from: /partners/
 ---
 
 
-# Zapier Trusted App Developers
+# Zapier trusted app developers
 
-If you don't have the time/resources to dedicate towards building and launching your own integration, there are  Zapier Trusted Developers who may be able to assist you. These are individuals/groups who have demonstrated their capabilities by satisfying our requirements for building apps on our Developer Platform, and we recommend as a substitute for building your integration in-house. 
+If you don't have the time/resources to dedicate towards building and launching your own integration, there are  Zapier trusted developers who may be able to assist you. These are individuals/groups who have demonstrated their capabilities by satisfying our requirements for building apps on our Developer Platform, and we recommend as a substitute for building your integration in-house. 
 
-## Approved Trusted Zapier App Developers
+## Approved trusted Zapier app developers
 
 * [Left Hook Digital](http://lefthookdigital.com/zapier-integration-developer-partner/)
 
@@ -24,15 +24,15 @@ If you don't have the time/resources to dedicate towards building and launching 
 
 If you're looking for help with Zap workflows and not building an app, contact one of our [Zapier Experts](https://zapier.com/experts/) who can help you out.
 
-> Note*: If you do work with one of our Zapier Trusted Developers to develop an app, make sure you develop a plan for continued support and maintenance, either using that developer, or with an in-house team who will take responsibility for the app.*
+> Note*: If you do work with one of our Zapier trusted developers to develop an app, make sure you develop a plan for continued support and maintenance, either using that developer, or with an in-house team who will take responsibility for the app.*
 
-## Requirements for becoming a Zapier Trusted Developer
+## Requirements for becoming a Zapier trusted developer
 
-In order to become a Zapier Trusted Developer, you must demonstrate your capabilities by satisfying the following requirements:
+In order to become a Zapier trusted developer, you must demonstrate your capabilities by satisfying the following requirements:
 
-* Develop and launch two Public apps that meet our [App Development Guide](https://zapier.com/developer/documentation/v2/app-dev-guide/) standards. This ensures that you're familiar with Zapier development, launch, promotion, and maintenance processes. You are responsible for finding clients who need Zapier integrations built.
+* Develop and launch two Public apps that meet our [Zapier integration branding and design guidelines](https://platform.zapier.com/partners/planning-guide) standards. This ensures that you're familiar with Zapier development, launch, promotion, and maintenance processes. You are responsible for finding clients who need Zapier integrations built.
 
-* The apps must have **sufficient complexity**, which includes a mix/quantity of Triggers, Actions, Searches, and/or Scripting. Barring this being present on the Public apps, you must demonstrate your competence with these features in another way, perhaps on an invite only app.
+* The apps must have **sufficient complexity**, which includes a mix/quantity of triggers, actions, searches, and/or scripting. Barring this being present on the public apps, you must demonstrate your competence with these features in another way, perhaps on an invite only app.
 
 * You are responsive when handling maintenance needs (bug fixes and feature requests), including being receptive to us increasing standards on the Developer Platform and adding new features, or moving to a newer version of the Developer Platform.
 

--- a/docs/_partners/zap-templates.md
+++ b/docs/_partners/zap-templates.md
@@ -1,44 +1,46 @@
 ---
-title: Zap Templates
-order: 11
+title: Zap templates
+order: 12
 layout: post-toc
 redirect_from: /partners/
 ---
 
-# Zap Templates
+# Zap templates
+> **Note:** Zap templates are available to all beta and public Zapier partners who own and maintain their own integration
 
 Zapier empowers apps to do together what they can’t on their own. With a bit of inspiration and creativity, your users can pull dozens of apps together into unique workflows to get more done with your app in far less time.
 
-Zap Templates are ready made integrations or Zaps with the apps and core fields pre-selected, for publicly available Zapier integrations. In a few clicks, they help people discover a use case, connect apps, and turn on the Zap. Zap Templates are the fastest way for your users to automate workflows.
+Zap templates are ready made integrations or Zaps with the apps and core fields pre-selected, for publicly available Zapier integrations. In a few clicks, they help people discover a use case, connect apps, and turn on the Zap. Zap templates are the fastest way for your users to automate workflows.
 
 <script type="text/javascript" src="https://zapier.com/apps/embed/widget.js?guided_zaps=192,111,162,1495,883"></script>
 
-They’re also a great way to promote your app, as your Zap Templates are featured in:
+They’re also a great way to promote your app, as your Zap templates are featured in:
 
-- Zapier’s App Directory
+- Zapier’s app directory
 - Zapier’s onboarding experience
 - In many of Zapier's {{ site.partner_count }} integration partners' apps and sites
 
-Zap Templates can also be featured inside your site and content to help your users start using Zapier integrations. The more Zap Templates you create and the more users they have, the more likely they are to be featured. This helps your Zapier integration gain popularity and rise the ranks of the [Zapier Partner Program](https://zapier.com/platform/partner-program). To learn more about embedding Zap Templates (and other experiences) into your app or website, see our dedicated [Embed](https://platform.zapier.com/embed/overview) section.
-
-You can create Zap Templates for any public Zapier integration. Once your integration is published, you will need to build at least 10 Zap Templates in the [Zap Template Creator](https://zapier.com/zap-templates/create) to join the [Partner Program](https://platform.zapier.com/partners/lifecycle-planning#4-launch-with-the-partner-program) and help people start using your integration.
+Zap templates can also be featured inside your site and content to help your users start using Zapier integrations. The more Zap templates you create and the more users they have, the more likely they are to be featured. This helps your Zapier integration gain popularity and rise the ranks of the [Zapier Partner Program](https://zapier.com/partners/partner-program). To learn more about embedding Zap templates (and other experiences) into your app or website, see our dedicated [embed](https://platform.zapier.com/embed/overview) section.
 
 > Expected time to create a Zap Template: 10 minutes.
 
 ![Example Zap Template](https://cdn.zappy.app/0d6ffaf492b547878ef8c06924a714f1.gif)
 _An example Zap Template that automatically saves Gmail attachments to Google Drive—a handy way to speed up email file management._
 
-## How to Build a Zap Template
+## How to build a Zap template
 
-Zap Templates take a few steps to build, similar to any other Zap. You first select the app and trigger you want to start the Zap, then add an action app and map the fields from the trigger app to the action—and optionally add additional steps. Then, add a title and description to help people quickly understand when to use your Zap.
+Zap templates take a few steps to build, similar to any other Zap. You first select the app and trigger you want to start the Zap, then add an action app and map the fields from the trigger app to the action—and optionally add additional steps. Then, add a title and description to help people quickly understand when to use your Zap.
+
 
 ### 1. Add a Trigger Step
 
 ![Zap Template select trigger app](https://cdn.zappy.app/64e407ae2b8e5f3ecaf9bedbbacd11d4.png)
 
-Open Zapier’s [Zap Template creator](https://zapier.com/zap-templates/create) at [zapier.com/zap-templates/create](https://zapier.com/zap-templates/create), or click the _Create Zap Template_ button in your [Zap Template dashboard](https://zapier.com/zap-templates/). Select the trigger app, as you would when making a Zap for yourself. Search for the app by name from the dropdown menu.
+Go to Zapier’s [Zap template creator](https://zapier.com/zap-templates/create) or from the [Zap Template dashboard](https://zapier.com/zap-templates/), click the _Create Zap Template_ button. 
 
-> **Tip:** The ability to build and publish Zap Templates is only available if your Zapier integration has a [beta tag](https://platform.zapier.com/partners/lifecycle-planning/#beta) or has [officially launched](https://platform.zapier.com/partners/lifecycle-planning#4-launch-your-zapier-integration) and become a part of the Zapier Integration Partner Program.
+Select the trigger app, as you would when making a Zap for yourself. Search for the app by name from the dropdown menu.
+
+> **Tip:** You can use Zapier integrations that are publicly available or that have applied to be launched publicly.
 
 ![Zap Template select trigger](https://cdn.zappy.app/bcf87bac5267b210d520cb97ac0e5612.png)
 
@@ -72,19 +74,19 @@ Choose the create or search action for your Zap. You may then be prompted to use
 
 > **Note**: If you use a search action, you need to also add a second action step to use the data from the trigger and search steps.
 
-As in the trigger step, when setting up most actions, you'll see a screen where your users will authenticate the action app—only in the Zap Template creator, Zapier uses this to pull in sample fields for the app.
+As in the trigger step, when setting up most actions, you'll see a screen where your users will authenticate the action app—only in the Zap template creator, Zapier uses this to pull in sample fields for the app.
 
 ![Zap Template form fields](https://cdn.zappy.app/42933f0f6a425d029429dbe918b0a107.png)
 
-Now for the most crucial part of your Zap Template: Map the input fields from the trigger app to the form fields in this action app. The action step’s template shows every field that Zapier can send to the app, with required and optional fields. For the best Zap Templates, you want to fill in as many form fields as possible to help users set up Zaps quickly.
+Now for the most crucial part of your Zap template: Map the input fields from the trigger app to the form fields in this action app. The action step’s template shows every field that Zapier can send to the app, with required and optional fields. For the best Zap templates, you want to fill in as many form fields as possible to help users set up Zaps quickly.
 
-> **Note**: Zap Templates' action fields _never_ show custom fields from apps, including spreadsheet columns, custom CRM fields, and other fields that are added by users, as Zapier's Template creator is not authenticated with an app account and custom fields will vary depending on the user. Your users will always need to add details to custom fields themselves.
+> **Note**: Zap templates' action fields _never_ show custom fields from apps, including spreadsheet columns, custom CRM fields, and other fields that are added by users, as Zapier's Template Creator is not authenticated with an app account and custom fields will vary depending on the user. Your users will always need to add details to custom fields themselves.
 
 For most form fields, you’ll need to add input fields from the trigger to the appropriate form field. Click into the form field and then `Show all options` button to see every input field from the trigger step. Select the input field that fits the action field best. For example, you might select Gmail’s _Attachment_ field to upload the attachment via Google Drive’s _File_ form field, or you might add Stripe’s _Email_ field to Mailchimp’s _Subscriber Email_ form field to add customers to an email list.
 
 > **Tip**: Use [Zapier’s date and time syntax](https://help.zapier.com/hc/en-us/articles/8496275717261) to modify dates and times in action form fields.
 
-Most dropdown menus are used to select folders, projects, and other user-generated data and should be left blank by default. You can, however, select options for dropdowns for boolean yes/no fields if you're certain which option is best for this Zap Template.
+Most dropdown menus are used to select folders, projects, and other user-generated data and should be left blank by default. You can, however, select options for dropdowns for boolean yes/no fields if you're certain which option is best for this Zap template.
 
 ![Zap Template required fields](https://cdn.zappy.app/e4222e2c4934485dd27454ef50f17ec0.png)
 
@@ -94,19 +96,19 @@ Zap Template action forms include _required_ and _optional_ fields. When users s
 
 ![Finish Zap Template Action](https://cdn.zappy.app/6e87adbfde77b00ae144b487c4185c20.png)
 
-Zapier then shows a test screen similar to what users see when setting up the Zap. Since you’re building a Zap Template, Zapier doesn’t create or add anything to your apps—the screen confirms everything should work correctly.
+Zapier then shows a test screen similar to what users see when setting up the Zap. Since you’re building a Zap template, Zapier doesn’t create or add anything to your apps—the screen confirms everything should work correctly.
 
-### 3. (Optional) Add Filters or Additional Action Steps
+### 3. (Optional) Add filters or additional action steps
 
-Now you have a choice: You can add another step to your Zap, or finish and save this Zap Template with only two steps.
+Now you have a choice: You can add another step to your Zap, or finish and save this Zap template with only two steps.
 
-Most Zap Templates only need two steps, with a Trigger to watch for data from an app and an Action to do something with that data. Sometimes, though, you need more steps for advanced workflows, including:
+Most Zap templates only need two steps, with a trigger to watch for data from an app and an action to do something with that data. Sometimes, though, you need more steps for advanced workflows, including:
 
 - **[Additional create actions](https://help.zapier.com/hc/en-us/articles/8496257774221-Set-up-your-Zap-action)** to add additional automations to your workflow
 - **[Filters](https://help.zapier.com/hc/en-us/articles/8496276332557)** to watch for specific items from trigger or action step(s)
 - **[Search actions](https://help.zapier.com/hc/en-us/articles/8496241402253)** to find specific data from apps, recommended especially to find customers, tickets, projects, and more before creating new items with Zaps
 
-> **Note**: You cannot build Paths in Zap Templates at this time.
+> **Note**: You cannot build Paths in Zap templates at this time.
 
 To add another search or create action to your Zap, click the _Add a Step_ button after setting up your action above, then repeat step 2 and set up the additional action. To add a _delay_ action, select the _Delay by Zapier_ app when adding a new action.
 
@@ -122,29 +124,29 @@ Then add details to the filter, if this Zap should always watch for the same dat
 
 Alternately, leave the filter details blank and let users customize the filter to their needs.
 
-> **Note**: Most Zap Templates don’t need filters, and most filters should be added by users later if required. However, including a filter in a Zap Template can be useful if your Zap Template is only useful with a filter to remove extraneous data.
+> **Note**: Most Zap templates don’t need filters, and most filters should be added by users later if required. However, including a filter in a Zap template can be useful if your Zap Template is only useful with a filter to remove extraneous data.
 
 <a id="shared-zaps-description"></a>
 
-### 4. Add a Title and Description
+### 4. Add a title and description
 
 ![Zap Template Description](https://cdn.zappy.app/44e237ef141178a3311bb96a9d8a1633.png)
 
-Now for the final step: add Zap Template’s title and description, then submit your Zap Template for review.
+Now for the final step: add Zap template’s title and description, then submit your Zap template for review.
 
-Zap Templates need to showcase a use case and describe it effectively. They provide inspiration for how to automate popular apps and workflows. Your Zap Template's description and title help sell that idea to users.
+Zap templates need to showcase a use case and describe it effectively. They provide inspiration for how to automate popular apps and workflows. Your Zap template's description and title help sell that idea to users.
 
 The title is the first thing people see. Embedded Zaps inside Zapier, your app, blog posts and other content show the Zap's title and app icons. Titles need to fit in well in each environment and sell the use case at a glance.
 
-Descriptions, then, are what users see when they click the Zap Template. They explain the use case and tell how the Zap works. The title grabs interest; the description gets people to invest the minute or three it takes to turn on the Zap.
+Descriptions, then, are what users see when they click the Zap template. They explain the use case and tell how the Zap works. The title grabs interest; the description gets people to invest the minute or three it takes to turn on the Zap.
 
-#### How to write a Zap Template title
+#### How to write a Zap template title
 
 ![Example Zap Template Title](https://cdn.zapier.com/storage/photos/fc6854d9f356bca06d8879a50ef41036.png)
 
-Zap Template titles clearly and briefly state the apps the Zap connects and the workflow it accomplishes. They include the trigger and action apps and the actions they perform. They use present tense, active voice, and sentence case.
+Zap template titles clearly and briefly state the apps the Zap connects and the workflow it accomplishes. They include the trigger and action apps and the actions they perform. They use present tense, active voice, and sentence case.
 
-Most Zap Template titles read something like this: `Add new Gmail emails to Google Sheets as rows`. The title mentions what happens in the trigger app followed by what Zapier does in the action app. Some examples of good titles:
+Most Zap template titles read something like this: `Add new Gmail emails to Google Sheets as rows`. The title mentions what happens in the trigger app followed by what Zapier does in the action app. Some examples of good titles:
 
 - `Create Trello cards for new Wufoo form entries`
 - `Get Slack notifications for new Google Drive files in a folder`
@@ -153,9 +155,9 @@ Most Zap Template titles read something like this: `Add new Gmail emails to Goog
 
 > **Tip**: Use your discretion whether to mention the action or trigger app first. The trigger app works best first in most cases, but sometimes it sounds awkward—if so, go with the action app first.
 
-Follow these rules in your Zap Template Titles:
+Follow these rules in your Zap template titles:
 
-- **Start with an appropriate verb**. Zap Templates start with an action verb that describes what the Zap does in the action app, such as `Create`, `Add`, `Make`, `Insert`, `Update`, `Subscribe`, or `Get`. Use unique verbs when possible, and use the most appropriate verb for the action Zapier performs with the app. For example:
+- **Start with an appropriate verb**. Zap templates start with an action verb that describes what the Zap does in the action app, such as `Create`, `Add`, `Make`, `Insert`, `Update`, `Subscribe`, or `Get`. Use unique verbs when possible, and use the most appropriate verb for the action Zapier performs with the app. For example:
   - Only use `Send` with messages, including emails and text messages
   - Only use `Post` with social network or chat apps
   - Only use `Log` or `Archive` with spreadsheet, database, or note-taking apps
@@ -171,9 +173,9 @@ Follow these rules in your Zap Template Titles:
 - **Never use `sync` or `automatic` in titles**. All Zaps run automatically, only work on new data, and can’t sync data multiple ways. Avoid these terms in titles; sync is misleading, and automatic is redundant.
 - **Don’t use personal pronouns**. Never use `you`, `we`, or `I` in Zap Template titles unless the trigger or action items specifically include those words.
 
-#### How to write a Zap Template description
+#### How to write a Zap template description
 
-Zap Template descriptions share more detail about what the Zap does and scenarios in which to use it in two to four sentences. They tell readers what this Zap does for them and how it works.
+Zap template descriptions share more detail about what the Zap does and scenarios in which to use it in two to four sentences. They tell readers what this Zap does for them and how it works.
 
 Start your description with the user's problem or need. Then explain how Zapier meets that need, when the Zap will run, and what the Zap does when it runs. Explain the trigger and action items in plain language that show the workflow's value. Some good examples:
 
@@ -187,45 +189,43 @@ Keep these guidelines in mind:
 
 - **Use present tense and active voice** as in the Zap title.
 - **1 paragraph, 2-4 sentences** is enough for most Zap Template descriptions.
-- **Don’t use Zapier-specific terminology** including Zap, Zap Template, trigger, action, or terms that Zapier doesn’t support, such as sync. Instead, use generic words, such as `integration` or `automation`, that are universally understood.
+- **Don’t use Zapier-specific terminology** including Zap, Zap template, trigger, action, or terms that Zapier doesn’t support, such as sync. Instead, use generic words, such as `integration` or `automation`, that are universally understood.
 - **Use same terms as the integrations themselves**. If an app calls the results of a form an “entry” don’t call it a “submission,” or if an email app uses "tags," don’t refer to "folders."
 - **Include tips at the end**. If your Zap Template requires extra setup for filters or other steps, or if it doesn't cover all use cases users may expect, include a sentence at the end to clarify. Start the tip with `Note:`, and format the entire note in italics with [Markdown](https://zapier.com/blog/beginner-ultimate-guide-markdown/) formatting. For example: `*Note: Add the tag you want to the Zap's [Filter](https://help.zapier.com/hc/en-us/articles/8496276332557) step.*`
 
-> **Note**: Always write unique descriptions for each Zap Template—we will reject Zap Templates that use the same descriptions but only replace app names.
+> **Note**: Always write unique descriptions for each Zap template—we will reject Zap templates that use the same descriptions but only replace app names.
 
 ---
 
-Once you've written and added your Zap Template title and description, it's time to save and test your work. Select `Draft` from the _Zap Template Visibility_ menu and click the _Save_ button.
+Once you've written and added your Zap template title and description, it's time to save and test your work. Select `Draft` from the _Zap Template Visibility_ menu and click the _Save_ button.
 
 ![Test Zap Template](https://cdn.zappy.app/c06a94f004e20748235d5de67efa2960.png)
 
-You should then try using the Zap Template to make sure it works as expected. Open your [Zap Template dashboard](https://zapier.com/zap-templates/), click the gear icon beside the Zap Template you built, and select _Copy Link_. Open that link in a new tab or window, and follow the steps to set up and turn on the Zap—and make sure everything looks and works correctly.
+You should then try using the Zap template to make sure it works as expected. Open your [Zap Template dashboard](https://zapier.com/zap-templates/), click the gear icon beside the Zap template you built, and select _Copy Link_. Open that link in a new tab or window, and follow the steps to set up and turn on the Zap—and make sure everything looks and works correctly.
 
-Optionally, you can let your team help test Zap Templates as well. When saving your Zap Template, choose `Shared` instead of draft, then share its link with others on your team so they can try the Zap Template.
+Optionally, you can let your team help test Zap templates as well. When saving your Zap template, choose `Shared` instead of draft, then share its link with others on your team so they can try the Zap template.
 
 <a id="submit-your-zap-templates"></a>
 
-### 5. Submit Zap Template for Review
+### 5. Submit Zap template for review
 
-Finally, when your Zap Template is ready for public release, select the `For review` option on your Zap Template Visibility menu, and click _Save_ again. That submits the Zap Template to our team to review the Zap Template and ensure it works as expected and meets our standards.
+Finally, when your Zap template is ready for public release, select the `For review` option on your Zap Template Visibility menu, and click _Save_ again. That submits the Zap template to our team to review the Zap template and ensure it works as expected and meets our standards.
 
-> **Note**: Zapier will only approve Zap Templates that include either public integrations or integrations that have applied for public release.
+We'll then contact you, typically within a couple of weeks, after reviewing your Zap template(s). If your Zap templates pass the tests, we will mark them as public to automatically have them show up on your app's app directory page, inside select partners' apps and sites, and in Zapier's onboarding experience.
 
-We'll then contact you, typically within a couple of weeks, after reviewing your Zap Template(s). If your Zap Templates pass the tests, we will mark them as public to automatically have them show up on your app's App Directory page, inside select partners' apps and sites, and in Zapier's onboarding experience.
+Then make some more Zap templates. The more you make, the easier it will be for users to start using your Zapier integration. 
 
-Then make some more Zap Templates. Every Zapier integration must have at least 10 Zap Templates, and the more you make, the easier it will be to start using your Zapier integration. Open the [Zap Template Creator](https://zapier.com/zap-templates/create) again and create any more Zap Templates you want.
+## Promote Your Zap templates
 
-## Promote Your Zap Templates
+It’s not enough to turn your ideal workflows into Zap templates. You need to get them in front of everyone who should use your Zaps. Zapier automatically promotes your Zap templates in our App Directory and in partner apps with embedded Zaps if your Zap templates include their apps. You can promote them further with a list of your Zap templates on your site, or include built-in Zap Template embeds inside your app.
 
-It’s not enough to turn your ideal workflows into Zap Templates. You need to get them in front of everyone who should use your Zaps. Zapier automatically promotes your Zap Templates in our App Directory and in partner apps with embedded Zaps if your Zap Templates include their apps. You can promote them further with a list of your Zap Templates on your site, or include built-in Zap Template embeds inside your app.
-
-### Zapier App Directory
+### Zapier app directory
 
 ![Zapier App Directory Page](https://cdn.zappy.app/f56ac65d2c36314bae02f21b00f983e4.png)
 
-The easiest way to find Zap Templates is in Zapier’s [App Directory](https://zapier.com/apps/) where we have individual pages for each of the {{ site.partner_count }} apps that integrate with Zapier. Want to find Gmail integrations? Go to [zapier.com/apps/gmail/integrations](https://zapier.com/apps/gmail/integrations/) to see the top apps connected with Gmail on Zapier, followed by a list of popular Gmail Zap Templates and Zapier content about Gmail use cases.
+The easiest way to find Zap templates is in Zapier’s [app directory](https://zapier.com/apps/) where we have individual pages for each of the {{ site.partner_count }} apps that integrate with Zapier. Want to find Gmail integrations? Go to [zapier.com/apps/gmail/integrations](https://zapier.com/apps/gmail/integrations/) to see the top apps connected with Gmail on Zapier, followed by a list of popular Gmail Zap templates and Zapier content about Gmail use cases.
 
-Find your app’s App Directory page at `zapier.com/apps/YourApp/integrations`, replacing `YourApp` with your app’s name.
+Find your app’s app directory page at `zapier.com/apps/YourApp/integrations`, replacing `YourApp` with your app’s name.
 
 ![Zapier App Directory two-app page](https://cdn.zappy.app/3937aa425d4ac71d0da24efd3a312829.png)
 
@@ -235,21 +235,21 @@ Find your app’s two-app pages at `zapier.com/apps/YourApp/integrations/OtherAp
 
 Zapier also shows these top use cases to logged in users, promoting your app’s top Zap Templates to people who have connected Zapier to your app.
 
-## Manage Your Zap Templates
+## Manage Your Zap templates
 
 ![Zap Template List](https://cdn.zappy.app/83e8b8cece2a25070406f94b3097473d.png)
 
-One Zap Template isn’t enough—you’ll want to make Zap Templates for each of your app’s most popular use cases. Over time, you’ll likely make dozens of Zap Templates. You can manage them—in draft, review, or publicly available—from your [Zap Templates](https://zapier.com/zap-templates/) dashboard alongside Zapier’s developer platform tools.
+One Zap template isn’t enough—you’ll want to make Zap templates for each of your app’s most popular use cases. Over time, you’ll likely make dozens of Zap templates. You can manage them—in draft, review, or publicly available—from your [Zap templates](https://zapier.com/zap-templates/) dashboard alongside Zapier’s Developer Platform tools.
 
-Filter through your Zap Templates by status on the left sidebar, click a Zap Template to edit it, or select the gear icon on the right of a Zap Template to copy its public link, test it, or delete it.
+Filter through your Zap templates by status on the left sidebar, click a Zap template to edit it, or select the gear icon on the right of a Zap template to copy its public link, test it, or delete it.
 
-If you have any Zap Templates in your _Rejected_ list, edit them to fix the issues then re-submit them. You cannot edit public Zap Templates, but if you notice something that you need to change in your existing Zap Templates, please email [partners@zapier.com](mailto:partners@zapier.com) with the link to the Zap Template, and we can set the Zap as _Draft_ again so you can edit and re-submit it with any changes.
+If you have any Zap templates in your _Rejected_ list, edit them to fix the issues then re-submit them. You cannot edit public Zap templates, but if you notice something that you need to change in your existing Zap Templates, please email [partners@zapier.com](mailto:partners@zapier.com) with the link to the Zap template, and we can set the Zap as _Draft_ again so you can edit and re-submit it with any changes.
 
-Then start again. Whenever you think of something that’s the _perfect_ use case for your Zapier integration, turn it into a Zap Template with the [Zap Template Creator](https://zapier.com/zap-templates/create). As soon as it’s approved, it’ll show up everywhere your Zapier integration is promoted, spreading your use case to the people who will benefit from it most.
+Then start again. Whenever you think of something that’s the _perfect_ use case for your Zapier integration, turn it into a Zap template with the [Zap Template Creator](https://zapier.com/zap-templates/create). As soon as it’s approved, it’ll show up everywhere your Zapier integration is promoted, spreading your use case to the people who will benefit from it most.
 
-### Promoting New Versions of your Integration
+### Promoting new versions of your integration
 
-When promoting a new version of your integration, all Zap Templates using the integration and having no breaking changes with the existing version will be updated to use the promoted version. The following are considered breaking changes:
+When promoting a new version of your integration, all Zap templates using the integration and having no breaking changes with the existing version will be updated to use the promoted version. The following are considered breaking changes:
 
 * A trigger/action is hidden or deleted.
 
@@ -259,10 +259,10 @@ When promoting a new version of your integration, all Zap Templates using the in
 
 * A trigger/action output field key is changed or removed.
 
-If breaking changes exist between the previous and newly promoted integration versions, Zap Templates will not be automatically updated and will continue to use the previous version.
+If breaking changes exist between the previous and newly promoted integration versions, Zap templates will not be automatically updated and will continue to use the previous version.
 
-### Deprecating Versions of your Integration
+### Deprecating versions of your integration
 
-When deprecating a version of your integration, any Zap Templates using the integration will automatically be marked as _Invalid_ within 24 hours of the deprecation.
+When deprecating a version of your integration, any Zap templates using the integration will automatically be marked as _Invalid_ within 24 hours of the deprecation.
 
-While invalid, the Zap Template will not be _Public_ until it is adjusted to use a non-deprecated version, re-submitted for review and approved. This ensures users won’t use deprecated and broken Zap Templates to make Zaps. If you’re having trouble accessing _Invalid_ templates, please [submit a ticket.](https://developer.zapier.com/contact)
+While invalid, the Zap template will not be _Public_ until it is adjusted to use a non-deprecated version, re-submitted for review and approved. This ensures users won’t use deprecated and broken Zap templates to make Zaps. If you’re having trouble accessing _Invalid_ templates, please [submit a ticket.](https://developer.zapier.com/contact)

--- a/docs/_partners/zim.md
+++ b/docs/_partners/zim.md
@@ -1,6 +1,6 @@
 ---
 title: Zapier Issue Manager
-order: 12
+order: 13
 layout: post-toc
 ---
 # Zapier Issue Manager
@@ -10,7 +10,7 @@ As users encounter bugs or think of new features they’d like within your integ
 
 If you prefer syncing and managing these requests from your own issue-tracking tools (such as Jira or Trello), you can create Zaps to do so using Zapier Issue Manager.
 
-Zapier Issue Manager makes it easy to engage with requests escalated by Zapier’s support team in a timely manner. This can help improve your integration’s [health score](https://platform.zapier.com/partners/partner-faq#how-is-my-integrations-health-score-calculated-how-can-i-improve-it) and increase your tier in the [Partner Program](https://zapier.com/platform/partner-program). The more you maintain a bug-free, quality integration, the more essential your product becomes to your users' workflows. This sets you up to reduce churn, drive account upgrades, and increase customer lifetime value.
+Zapier Issue Manager makes it easy to engage with requests escalated by Zapier’s support team in a timely manner. This can help improve your integration’s [health score](https://platform.zapier.com/partners/partner-program#integration-health-score) and increase your tier in the [Partner Program](https://zapier.com/platform/partner-program). The more you maintain a bug-free, quality integration, the more essential your product becomes to your users' workflows. This sets you up to reduce churn, drive account upgrades, and increase customer lifetime value.
 
 ## Who can use Zapier Issue Manager?
 
@@ -35,7 +35,7 @@ Zapier Issue Manager offers the following features:
 * Find Issue
 * Generate Report
 
-##  Get Started Using Zapier Issue Manager
+##  Get started Using Zapier Issue Manager
 
 Here are some Zap templates to help you get started using Zapier Issue Manager.
 


### PR DESCRIPTION
- Removed reference to old beta phase requirements
- Created two new articles:
  -  About the Partner Program (moved as it was buried in Partner FAQ)
  - Get help with the Developer Platform (moved as it was buried in Integration FAQ)
 - Updated articles:
 -  Build your first public integration on Zapier (previously, how to build and publish an integration
 - Zapier integration review guidelines


I've updated the entire folder for Partners content:
- Reordered the docs
- Changed all titles and headers to sentence case
- Removed FAQ from page titles (URLs for existing pages are unaffected)
- Updated titles to reflect titles on the page
- Fix terminology on words that were incorrectly capitalised, in line with the Content and Messaging Guidelines.