### PR TITLE
[PARTOPS-666] Update embed platform docs with videos

### DIFF
--- a/docs/_embed/automatic_account_creation.md
+++ b/docs/_embed/automatic_account_creation.md
@@ -9,14 +9,6 @@ redirect_from: /partner_api/
 
 Save time and reduce friction for your users by having a Zapier account created on their behalf when using one of our product embeds.  Users no longer need to worry about the hassle of signing up to a new service.
 
-The below video shows the signup flow on Google's embed experience without automatic account creation. To sign up, users are required to manually provide first and last name, email address, and go through a multi-step onboarding survey before arriving at the Zap Editor:
-
-<iframe allowtransparency="true" title="Wistia video player" allowFullscreen frameborder="0" scrolling="no" class="wistia_embed" name="wistia_embed" src="https://fast.wistia.net/embed/iframe/tqz0movaqf" width="400" height="225"></iframe>
-
-In comparison, the below videeo shows the signup flow with automatic account creation enabled. To sign up, users confirm on a consent screen and then are directed to the Zap Editor:
-
-<iframe allowtransparency="true" title="Wistia video player" allowFullscreen frameborder="0" scrolling="no" class="wistia_embed" name="wistia_embed" src="https://fast.wistia.net/embed/iframe/e66sqvvd20" width="400" height="225"></iframe>
-
 Zapier accomplishes this by being an OpenID Connect relaying party.  Partners who support being an identity provider and are able to communicate via OpenID Connect can take advantage of this new communication channel.
 
 In order to help customers feel secure during this exchange of profile information, Zapier has added an acknowledgement page that will be presented before the partner’s OpenID Connect consent screen.  This acknowledgement page informs the end user why their profile information is being exchanged and that a new account is being created on their behalf.
@@ -24,6 +16,18 @@ In order to help customers feel secure during this exchange of profile informati
 Following account creation the end user will be sent an email to let them know a Zapier account has been created, how to set a password on their new account, and highlight the partner that brought them to Zapier.
 
 <a class="button" style="background-color:#20272B;color:white" href="https://zapier.typeform.com/to/OlPloIcW/?utm_source=zapier_marketing_website&utm_medium=embed_experience&utm_campaign=solutions_marketing_page">Enable this for your product</a>
+
+## Example Implementation
+
+The below video shows the signup flow on Google's embed experience without automatic account creation. To sign up, users are required to manually provide first and last name, email address, and go through a multi-step onboarding survey before arriving at the Zap Editor:
+
+<iframe allowtransparency="true" title="Wistia video player" allowFullscreen frameborder="0" scrolling="no" class="wistia_embed" name="wistia_embed" src="https://fast.wistia.net/embed/iframe/tqz0movaqf" width="640" height="360"></iframe>
+
+
+In comparison, the below videeo shows the signup flow with automatic account creation enabled. To sign up, users confirm on a consent screen and then are directed to the Zap Editor:
+
+<iframe allowtransparency="true" title="Wistia video player" allowFullscreen frameborder="0" scrolling="no" class="wistia_embed" name="wistia_embed" src="https://fast.wistia.net/embed/iframe/e66sqvvd20" width="640" height="360"></iframe>
+
 
 ## Requirements
 

--- a/docs/_embed/full_zapier_experience.md
+++ b/docs/_embed/full_zapier_experience.md
@@ -14,6 +14,12 @@ The Full Zapier Experience is a prebuilt UI component that offers the quickestâ€
 
 With the Full Zapier Experience, you can create a seamless experience for your users that allows them to automate workflows without having to switch tasks or apps halfway through a job.
 
+## Example Implementation
+This video shows an example implementation of the Full Zapier Experience, and how users can discover workflow use cases, create and edit Zaps, and manage their existing Zaps all within your platform:
+
+<iframe allowtransparency="true" title="Wistia video player" allowFullscreen frameborder="0" scrolling="no" class="wistia_embed" name="wistia_embed" src="https://fast.wistia.net/embed/iframe/84kpi5zau6" width="640" height="360"></iframe>
+
+
 ## Customize
 ![Customize](https://cdn.zappy.app/2f5e6152ad6c3a807d210f0c6746c890.png)
 

--- a/docs/_embed/partner_api.md
+++ b/docs/_embed/partner_api.md
@@ -876,6 +876,22 @@ All errors will be JSON object with a String array of errors:
 }
 ```
 
+## Example Implementations
+Jotform uses the `/apps` endpoint to power their own app directory by intertwining the thousands of public integrations on Zapier's directory with their native integrations:
+
+<iframe allowtransparency="true" title="Wistia video player" allowFullscreen frameborder="0" scrolling="no" class="wistia_embed" name="wistia_embed" src="https://fast.wistia.net/embed/iframe/qk2x3cwnzt" width="640" height="360"></iframe>
+
+
+Wufoo uses the `/zap-templates` endpoint to retrieve raw data about their Zap Templates to customize the look and feel of how they are surfaced to users within their own integration directory:
+
+<iframe allowtransparency="true" title="Wistia video player" allowFullscreen frameborder="0" scrolling="no" class="wistia_embed" name="wistia_embed" src="https://fast.wistia.net/embed/iframe/j8t914xl0y" width="640" height="360"></iframe>
+
+
+Unbounce uses the `/zaps` endpoint to display users' Zaps using their integration directly within the Unbounce platform:
+
+<iframe allowtransparency="true" title="Wistia video player" allowFullscreen frameborder="0" scrolling="no" class="wistia_embed" name="wistia_embed" src="https://fast.wistia.net/embed/iframe/zhls72cz15" width="640" height="360"></iframe>
+
+
 ## Changelog
 - 2023-05-25
 

--- a/docs/_embed/zap_templates.md
+++ b/docs/_embed/zap_templates.md
@@ -1,7 +1,7 @@
 ---
 title: Zap Templates
 order: 3
-layout: post
+layout: post-toc
 redirect_from: 
   - /partner_api/embedding
 ---
@@ -18,3 +18,9 @@ Want to embed specific Zap Templates instead? Simply select the Custom selected 
 
 
 Find the Zap Templates generator under Embed on the left-hand menu in the [Developer Platform](https://developer.zapier.com/).
+
+## Example Implementation
+
+This video shows an example implementation of the Zap Templates element embedded within the Zoho Sheet platform to surface popular workflows for users to easily discover and create Zaps:
+
+<iframe allowtransparency="true" title="Wistia video player" allowFullscreen frameborder="0" scrolling="no" class="wistia_embed" name="wistia_embed" src="https://fast.wistia.net/embed/iframe/hg0qtkr80v" width="640" height="360"></iframe>


### PR DESCRIPTION
[Thread with Brian from TPS ](https://zapier.slack.com/archives/CH0SN5V0V/p1685472701821929)on adding embed example videos from the "Embed" tab of the developer platform to our platform docs.

Tested embedding the video on the [AAC page](https://platform.zapier.com/embed/automatic-account-creation) via this [PR](https://github.com/zapier/visual-builder/pull/454). The video embeds fine, just needed to set the correct sizing so the video content is more easily visible. The height and width of the video is adjusted in this PR! 