### PR TITLE
Fixing typo in migration warning callout in versioning doc

### DIFF
--- a/docs/_docs/versions.md
+++ b/docs/_docs/versions.md
@@ -118,7 +118,7 @@ In some cases, it may be more useful to migrate only a portion of the current us
 
 ![Using the Percentage slider to migrate only 55% of users](https://cdn.zappy.app/68a6701f418dbda95771258703cc609a.png)
 
-> **Warning:** By default, migrating a single user with the "migrate by email" option will only migrate Zaps that are *private to that user*—owned by the user, are not shared, and whose the integration auths are not shared.
+> **Warning:** By default, migrating a single user with the "migrate by email" option will only migrate Zaps that are *private to that user*—owned by the user, are not shared, and whose integration auths are not shared.
 
 You can then repeat the Migration process later on, and migrate the rest of the users once you are comfortable with how the new version is running in production.
 


### PR DESCRIPTION
This fixes a tiny typo in the Versioning doc's migration warning callout, where I'd previously entered an extra "the."

https://cdn.zappy.app/57eb583bcf00b70b1c1e95aa74eb3125.png