### PR TITLE
Fix search's matchStrength to allow backward search

### DIFF
--- a/_includes/search.html
+++ b/_includes/search.html
@@ -127,7 +127,7 @@ const matchStrength = (query, post) => {
     * Search through the content and title with the whole query,
     * then remove the first term, repeating until there are no more terms.
     */ 
-    const forwardSearch = queryTerms;
+    const forwardSearch = [...queryTerms];
     while (forwardSearch.length > 0) {
         const regex = new RegExp(forwardSearch.join(' '), 'gi');
         strength += [...post.content.matchAll(regex)].length * forwardSearch.length;
@@ -139,7 +139,7 @@ const matchStrength = (query, post) => {
     * Search through the content and title with the whole query,
     * then remove the last term, repeating until there are no more terms.
     */ 
-    const backwardSearch = queryTerms;
+    const backwardSearch = [...queryTerms];
     while (backwardSearch.length > 0) {
         const regex = new RegExp(backwardSearch.join(' '), 'gi');
         strength += [...post.content.matchAll(regex)].length * backwardSearch.length;


### PR DESCRIPTION
This request aims to make `forwardSearch` and `backwardSearch` shallow copies of `queryTerms` in the `matchStrength` function, which determines the relevance of search results. 

At present, `forwardSearch` is a direct reference, so when we splice in the loop, we mutate `queryTerms`. As a result, `backwardSearch` gets initialized as an empty array, so AFAIK, we never actually run the backward search. 

![issue](https://cdn.zappy.app/11e59700a558cedadacdaa09249b3191.png)

I don't expect this to change search results much as it would really only affect queries of 3 words or more. But I think it's still work making the function work as it _appears_ it should work, and as the comment describes.