### PR TITLE
Fix: Broken Deploy Keys link and broken Platform docs links

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Zapier Platform UI is the easiest way to build new Zapier integrations in an onl
 
 Zapier Platform CLI is the most advanced way to build integrations in your local development environment with your team's source code management and custom testing.
 
-- Install Zapier Platform CLI and build a sample integration in the [CLI Quick Start guide](https://zapier.com/developer/start/introduction)
+- Install Zapier Platform CLI and build a sample integration in the [CLI Quick Start guide](https://platform.zapier.com/cli_docs/docs#quick-setup-guide)
 - Find detailed info on the Zapier Platform in the [Zapier Platform Schema](https://github.com/zapier/zapier-platform/blob/main/packages/schema/docs/build/schema.md) from our built-in code docs
 - Start quicker with our template [Zapier CLI Example Apps](https://github.com/zapier/zapier-platform/wiki/Example-Apps)
 - Learn more in [Zapier's Platform CLI Documentation](https://platform.zapier.com/cli_docs/docs)

--- a/docs/_cli_docs/docs.md
+++ b/docs/_cli_docs/docs.md
@@ -151,7 +151,7 @@ This doc describes the latest CLI version (**14.1.1**), as of this writing. If y
 
 ## Getting Started
 
-> If you're new to Zapier Platform CLI, we strongly recommend you to walk through the [Tutorial]() for a more thorough introduction.
+> If you're new to Zapier Platform CLI, we strongly recommend you to walk through the [Tutorial](https://platform.zapier.com/cli_tutorials/getting-started) for a more thorough introduction.
 
 ### What is an App?
 

--- a/docs/_cli_docs/docs.md
+++ b/docs/_cli_docs/docs.md
@@ -209,7 +209,7 @@ npm install -g zapier-platform-cli
 # setup auth to Zapier's platform with a deploy key
 zapier login
 ```
-> Note: If you log into Zapier via the single sign-on (Google, Facebook, or Microsoft), you may not have a Zapier password. If that's the case, you'll need to generate a deploy key, go to [your Zapier developer account here](https://zapier.com/developer/partner-settings/deploy-keys/) and create/copy a key, then run ```zapier login``` command with the --sso flag.
+> Note: If you log into Zapier via the single sign-on (Google, Facebook, or Microsoft), you may not have a Zapier password. If that's the case, you'll need to generate a deploy key, go to [your Zapier developer account here](https://developer.zapier.com/partner-settings/deploy-keys/) and create/copy a key, then run ```zapier login``` command with the --sso flag.
 
 Your Zapier CLI should be installed and ready to go at this point. Next up, we'll create our first app!
 
@@ -869,7 +869,7 @@ If you define `fields` to collect additional details from the user, please note 
 
 *Added in v14.0.0.*
 
-Zapier's OAuth2 implementation also supports [PKCE](https://oauth.net/2/pkce/). This implementation is an extension of the OAuth2 `authorization_code` flow described above. 
+Zapier's OAuth2 implementation also supports [PKCE](https://oauth.net/2/pkce/). This implementation is an extension of the OAuth2 `authorization_code` flow described above.
 
 To use PKCE in your OAuth2 flow, you'll need to set the following variables:
   1. `enablePkce: true`
@@ -2499,7 +2499,7 @@ Dehydration, and its counterpart Hydration, is a tool that can lazily load data 
 
 The method `z.dehydrate(func, inputData)` has two required arguments:
 
-* `func` - the function to call to fetch the extra data. Can be any raw `function`, defined in the file doing the dehydration or imported from another part of your app. You must also register the function in the app's `hydrators` property. Note that since v10.1.0, the maximum payload size to pass to `z.dehydrate` / `z.dehydrateFile` is 6KB. 
+* `func` - the function to call to fetch the extra data. Can be any raw `function`, defined in the file doing the dehydration or imported from another part of your app. You must also register the function in the app's `hydrators` property. Note that since v10.1.0, the maximum payload size to pass to `z.dehydrate` / `z.dehydrateFile` is 6KB.
 * `inputData` - this is an object that contains things like a `path` or `id` - whatever you need to load data on the other side
 
 > **Why do I need to register my functions?** Because of how JavaScript works with its module system, we need an explicit handle on the function that can be accessed from the App definition without trying to "automagically" (and sometimes incorrectly) infer code locations.
@@ -2847,7 +2847,7 @@ const yourAfterResponse = (resp) => {
 ```
 Instead of a user’s Zap erroring and halting, the request will be repeatedly retried at the specified time.
 
-For throttled requests that occur during processing of a webhook trigger's perform, before results are produced; there is a max retry delay of 300 seconds and a default delay of 60 seconds if none is specified. For webhook processing only, if a request during the retry attempt is also throttled, it will not be re-attempted again. 
+For throttled requests that occur during processing of a webhook trigger's perform, before results are produced; there is a max retry delay of 300 seconds and a default delay of 60 seconds if none is specified. For webhook processing only, if a request during the retry attempt is also throttled, it will not be re-attempted again.
 
 ## Testing
 

--- a/docs/_cli_docs/docs.md
+++ b/docs/_cli_docs/docs.md
@@ -151,7 +151,7 @@ This doc describes the latest CLI version (**14.1.1**), as of this writing. If y
 
 ## Getting Started
 
-> If you're new to Zapier Platform CLI, we strongly recommend you to walk through the [Tutorial](https://zapier.com/developer/start) for a more thorough introduction.
+> If you're new to Zapier Platform CLI, we strongly recommend you to walk through the [Tutorial]() for a more thorough introduction.
 
 ### What is an App?
 
@@ -246,7 +246,7 @@ zapier push
 
 ### Tutorial
 
-For a full tutorial, head over to our [Tutorial](https://zapier.com/developer/start) for a comprehensive walkthrough for creating your first app. If this isn't your first rodeo, read on!
+For a full tutorial, head over to our [Tutorial](https://platform.zapier.com/cli_tutorials/getting-started) for a comprehensive walkthrough for creating your first app. If this isn't your first rodeo, read on!
 
 ## Creating a Local App
 

--- a/docs/_docs/export.md
+++ b/docs/_docs/export.md
@@ -27,7 +27,7 @@ We created the visual builder to be the easiest way for everyone to get started 
 
 _Step 1: Install and configure the Zapier CLI on your development environment._
 
-Follow the steps in the setup section in our [quickstart guide](https://zapier.com/developer/start/introduction)
+Follow the steps in the setup section in our [quickstart guide](https://platform.zapier.com/cli_docs/docs#quick-setup-guide)
 
 _Step 2: Run the `convert` command to create a CLI version of your project locally_
 

--- a/docs/_docs/vs.md
+++ b/docs/_docs/vs.md
@@ -98,7 +98,7 @@ Zapier CLI lets you build advanced integrations faster than visual builder since
 
 Choose CLI if your API needs custom coding for most API calls or you find writing integrations in code easier than using a web app, and if your integration will maintained by an engineering team. Zapier CLI is more difficult to use for non-engineers, but will likely be more efficient for an engineering team to use than visual builder. And soon, you won't have to choose: You can start with visual builder, then switch to CLI later if you want.
 
-_‌→ Install Zapier Platform CLI with `npm install -g zapier-platform-cli`, check our [CLI Quick Start Guide](https://zapier.com/developer/start/introduction) to build a demo integration, then learn more in [Zapier's CLI documentation](https://zapier.github.io/zapier-platform-cli/)._
+_‌→ Install Zapier Platform CLI with `npm install -g zapier-platform-cli`, check our [CLI Quick Start Guide](https://platform.zapier.com/cli_docs/docs#quick-setup-guide) to build a demo integration, then learn more in [Zapier's CLI documentation](https://zapier.github.io/zapier-platform-cli/)._
 
 ## Switching from the UI to the CLI
 

--- a/docs/_legacy/import.md
+++ b/docs/_legacy/import.md
@@ -103,4 +103,4 @@ Want to start over and build a new integration, or add another integration for a
 
 Choose the Platform UI to build your integration online with a visual builder to create input forms for your triggers and actions and add API details in minutes. Or, choose the Platform CLI to code your integration in JavaScript, manage versions in your team's version control, and manage your integration from terminal.
 
-Try the tool of your choice out with Zapier's [Platform UI Quick Start guide](https://platform.zapier.com/quickstart/introduction) and [CLI Quick Start guide](https://zapier.com/developer/start/introduction), then check our documentation to build a complete new integration.
+Try the tool of your choice out with Zapier's [Platform UI Quick Start guide](https://platform.zapier.com/quickstart/introduction) and [CLI Quick Start guide](https://platform.zapier.com/cli_docs/docs#quick-setup-guide), then check our documentation to build a complete new integration.


### PR DESCRIPTION
Changes in this PR:

1. Fix deploy key link (reported [via Slack](https://zapier.slack.com/archives/C5Z9BP4U9/p1687177914762379))
* `https://zapier.com/developer/partner-settings/deploy-keys/ ` -> `https://developer.zapier.com/partner-settings/deploy-keys/`

2. Updated a few broken platform documentation links:

* `https://zapier.com/developer/start/introduction` -> `https://platform.zapier.com/cli_docs/docs#quick-setup-guide`
* `https://zapier.com/developer/start` -> `https://platform.zapier.com/cli_tutorials/getting-started`

3. Looks like some end-of-line encoding changes got included from my VSCode's autosave?