### PR TITLE
[PARTOPS-689] Remove two outdated bullets about embed domains

### DIFF
--- a/docs/_embed/full_zapier_experience.md
+++ b/docs/_embed/full_zapier_experience.md
@@ -19,11 +19,13 @@ This video shows an example implementation of the Full Zapier Experience, and ho
 
 <iframe allowtransparency="true" title="Wistia video player" allowFullscreen frameborder="0" scrolling="no" class="wistia_embed" name="wistia_embed" src="https://fast.wistia.net/embed/iframe/84kpi5zau6" width="640" height="360"></iframe>
 
-
 ## Customize
 ![Customize](https://cdn.zappy.app/2f5e6152ad6c3a807d210f0c6746c890.png)
 
-Our [generator](https://zapier.com/partner/solutions/plug-and-play) lets you customize the visual design and features of Zapier you want to include, and generate code snippets that can be copied and pasted directly into your site. No engineering resources are required!
+Our [generator](https://zapier.com/partner/solutions/plug-and-play) lets you customize the visual design and features of Zapier you want to include, and generate code snippets that can be copied and pasted directly into your site. Generate the embed code in HTML, Vanilla JS, React, Angular, or Vue.js 2. No engineering resources are required!
+
+![Implementation](https://cdn.zappy.app/474db8b4962835b00bcf1c91b03e0156.png)
+
 
 Find the Full Zapier Experience under Embed on the left-hand menu in the [Developer Platform](https://developer.zapier.com/).
 

--- a/docs/_embed/security.md
+++ b/docs/_embed/security.md
@@ -16,5 +16,3 @@ Our user's security is paramount. By default, we deny any embedding of our produ
 To provide us a list of unique domains you'll embed Zapier in:
 
 - if you've already embedded our Product, you're in luck! We should have already captured this and have permitted your product domains. Should we have missed any, navigate to the Embed > Settings section of the [Developer Platform](https://developer.zapier.com/), and add the missing domains under the `Embedding Domains` tab.
-- else if you've already applied for a Partner API access: contact [partners@zapier.com](mailto:partners@zapier.com) and include the domains you'd like to register.
-- otherwise, when you [apply for the Partner API access](https://zapier.typeform.com/to/atnWuF) you'll have the opportunity to supply us the embedding domains inside of the form.


### PR DESCRIPTION
* Remove two outdated bullets about embed domains
* Also clarifies on the FZE page what frameworks/langs you can generate code in - this was feedback from the FZE survey.