### PR TITLE
Fix category text in Partner API docs

### DIFF
--- a/docs/_embed/partner_api.md
+++ b/docs/_embed/partner_api.md
@@ -564,12 +564,12 @@ Available parameters to the categories resource:
 
 | parameter  | requirement | notes                                                                                                                                                  |
 | ---------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **limit**  | Optional    | (defaults to 10, max of 100) Limit the number of Zap templates returned.                                                                               |
+| **limit**  | Optional    | (defaults to 10, max of 100) Limit the number of categories. returned.                                                                               |
 | **offset** | Optional    | (defaults to 0) The number of categories items to skip before returning new categories. The default value is 0, which is the offset of the first item. |
 
 **Example Requests**
 
-Get a list of Zap categories
+Get a list of app categories
 
 ```bash
 curl -L "https://api.zapier.com/v1/categories"


### PR DESCRIPTION
Fixing two super quick copypasta issues found in the Partner API docs.