### PR TITLE
Fix platform.zapier.com/docs infinite redirect loop

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,5 +1,6 @@
 ---
 layout: default
+redirect_from: /docs
 ---
 # Zapier Platform Docs
 


### PR DESCRIPTION
The /docs should now redirect to the homepage. Tested locally and could not spot any issues.

* See issue report: https://zapier.slack.com/archives/C04P5J5R8E4/p1689341773107969?thread_ts=1689334102.378179&cid=C04P5J5R8E4

* Fix suggested by @jessveegee here: https://zapier.slack.com/archives/C04P5J5R8E4/p1689348494318529?thread_ts=1689334102.378179&cid=C04P5J5R8E4