### PR TITLE
Fix: Add underline under "Documentation" in the header

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -4,7 +4,7 @@
   <ul class="platform-header__links">
     <li><a href="https://zapier.com/platform/how-to-build">How to Build</a></li>
     <li><a href="https://zapier.com/platform/partner-program">Partner Program</a></li>
-    <li><a href="https://platform.zapier.com/">Documentation</a></li>
+    <li><a href="/" class="platform-header__selected">Documentation</a></li>
     <li><a href="https://community.zapier.com/for-developers-61">Developer Community</a></li>
     <li><a href="https://developer.zapier.com/contact">Help</a></li>
   </ul>


### PR DESCRIPTION
The underline under "Documentation" was accidentally removed in this PR: https://github.com/zapier/visual-builder/pull/477

Fix spotted by @robertscl 💯 https://zapier.slack.com/archives/C04P5J5R8E4/p1689367201972169?thread_ts=1689334102.378179&cid=C04P5J5R8E4