### PR TITLE
[PARTOPS-733] Add redirect and fix legacy links around docs

### DIFF
--- a/docs/_manage/analyze-integration-performance.md
+++ b/docs/_manage/analyze-integration-performance.md
@@ -157,7 +157,7 @@ Active user retention is not a leading indicator. In fact, it’s quite a laggin
 Approaching active user retention with a long-term strategy can help maintain a consistently high level of retention:
  
 * [Embed](https://platform.zapier.com/embed/overview) the Zapier experience with copy-and-paste and customizable code within your platform to provide automation value directly to users. Embeds have proven to [reduce churn](https://platform.zapier.com/partner_success_stories/all) on Partners’ platforms. Find live embed examples under the ‘Embed’ tab of the integration’s developer platform.
-* [Share use cases](https://platform.zapier.com/publish/partner-program-tips#tip-4-share-zapier-use-cases-in-your-onboarding) widely during your platform’s onboarding process. Having multiple Zaps using your integration increases stickiness of users not only to the Zapier integration, but also to your platform.
+* [Share use cases](https://platform.zapier.com/publish/partner-faq#tip-4-share-zapier-use-cases-in-your-onboarding) widely during your platform’s onboarding process. Having multiple Zaps using your integration increases stickiness of users not only to the Zapier integration, but also to your platform.
 * Update the integration regularly with features as your platform evolves. [Invite stakeholders to your integration](https://platform.zapier.com/manage/invite-team-member) to give them admin or read-only access to insights, metrics, and feedback to prioritize and align improvements. 
 
 

--- a/docs/_publish/partner-faq.md
+++ b/docs/_publish/partner-faq.md
@@ -2,7 +2,9 @@
 title: Zapier Partner Program tips
 order: 7
 layout: post-toc
-redirect_from: /partners/partner-faq
+redirect_from:
+    - /partners/partner-faq
+    - /publish/partner-program-tips
 ---
 
 # Zapier Partner Program tips

--- a/docs/_publish/partner-program.md
+++ b/docs/_publish/partner-program.md
@@ -38,7 +38,7 @@ Zapier won’t externally share your level in the Partner Program with anyone, i
 
 The active users metric looks at how many people are actively using your Zapier integration this quarter. Since this number accumulates over the quarter, it is normal to see a drop at the beginning of each quarter compared to the end of last quarter.
 
-To increase usage of your Zapier integration, try out [these 10 tactics](https://platform.zapier.com/publish/partner-program-tips).
+To increase usage of your Zapier integration, try out [these 10 tactics](https://platform.zapier.com/publish/partner-faq).
 
 
 ### Integration health score

--- a/docs/_publish/public-integration.md
+++ b/docs/_publish/public-integration.md
@@ -111,7 +111,7 @@ Learn more about[ embedding Zapier](https://platform.zapier.com/embed/overview).
 
 During the beta stage of your integration, it's important to actively work on growing the usage of your app. By encouraging more people to use your integration, you'll be able to gather valuable insights and feedback early on, which will help you optimize it further.
 
-Learn more strategy[ tips to improve your integration](https://platform.zapier.com/publish/partner-program-tips).
+Learn more strategy[ tips to improve your integration](https://platform.zapier.com/publish/partner-faq).
 
 ### **Manage bugs and feature requests**
 


### PR DESCRIPTION
User reported to Ilia that [this section](https://platform.zapier.com/publish/partner-program-tips) in the documentation is throwing a 404.

* Fixed mentions of the broken link directly in the platform docs
* Added a redirect to the Partner Program Tips page in case that link is used/lingering elsewhere.