### PR TITLE
Added recommendation for using `bundle.meta.isLoadingSample` to determine execution state in Zapier CLI documentation.

### DIFF
--- a/docs/_reference/cli-docs.md
+++ b/docs/_reference/cli-docs.md
@@ -1842,6 +1842,7 @@ For example, in your `perform` you might do:
 const perform = async (z, bundle) => {
   // something like this url:
   // https://zapier.com/hooks/callback/123/abcdef01-2345-6789-abcd-ef0123456789/abcdef0123456789abcdef0123456789abcdef01/
+  // consider checking bundle.meta.isLoadingSample to determine if this is a test run or real run!
   const callbackUrl = z.generateCallbackUrl();
   await z.request({
     url: 'https://example.com/api/slow-job',
@@ -1864,6 +1865,8 @@ Content-Type: application/json
 
 {"foo":"bar"}
 ```
+
+> We recommend using `bundle.meta.isLoadingSample` to determine if the execution is happening in the foreground (IE: during Zap setup) as using `z.generateCallbackUrl()` can be inappropriate given the disconnect. Instead, wait for the long running request without generating a callback, or if you must, return stubbed data.
 
 And finally, in a `performResume` to handle the final step which will receive three bundle properties:
 


### PR DESCRIPTION
This should help resolve some outstanding issues with callbacks we observe, at least during testing.

Though I seem to recall conversations about our sampling service supporting this natively. Did that ever happen?