### PR TITLE
PDE-4260: Add invisible page that redirects to github schema docs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,7 @@ url: "https://platform.zapier.com" # the base hostname & protocol for your site,
 markdown: kramdown
 baseurl: "" # intentionally left blank, site is served at root
 partner_api_invite_url: "https://zapier.typeform.com/to/atnWuF"
-partner_count: "5,000+"
+partner_count: "6,000+"
 
 plugins:
   - jekyll-redirect-from
@@ -35,6 +35,9 @@ collections:
     output: true
     permalink: /:collection/:name    
   reference:
+    output: true
+    permalink: /:collection/:name
+  cli_docs:
     output: true
     permalink: /:collection/:name
 
@@ -70,4 +73,8 @@ defaults:
       type: "reference"
     values:
       layout: default
-
+  - scope:
+      path: ""
+      type: "cli_docs"
+    values:
+      layout: default

--- a/docs/_cli_docs/schema.md
+++ b/docs/_cli_docs/schema.md
@@ -1,0 +1,24 @@
+---
+# Note - this page current serves the Zapier CLI tooling which links to a page that no longer has content. This script is a redirect to the Github schema docs. We can remove this after all Zapier versions no longer make references to the old docs link here. Related ticket: https://zapierorg.atlassian.net/browse/PDE-4180
+order: 1000
+---
+
+<script>
+(function() {
+  var fallbackUrl = 'https://github.com/zapier/zapier-platform/blob/master/packages/schema/docs/build/schema.md';
+  var hash = window.location.hash;
+  var hashParts, newAnchor, version;
+  if (hash) {
+    hashParts = window.location.hash.split('@');
+    if (hashParts.length === 2) {
+      newAnchor = hashParts[0];
+      version = hashParts[1];
+      window.location.assign(`https://github.com/zapier/zapier-platform/blob/zapier-platform-schema@${version}/packages/schema/docs/build/schema.md${newAnchor}`);
+    } else {
+      window.location.assign(fallbackUrl);
+    }
+  } else {
+    window.location.assign(fallbackUrl);
+  }
+})();
+</script>


### PR DESCRIPTION
https://zapierorg.atlassian.net/browse/PDE-4260

Context:
When building on the CLI tool, builders often use `zapier validate` to verify their app is written correctly.
```
cli-apps/taylorswift [ z validate                                                                                  ] 1:15 pm
Validating project locally
┌─────────────┬─────────────────────────────────────────────────────────────────────────┐
│ Property    │ App.authentication                                                      │
│ Message     │ additionalProperty "sus" exists in instance when not allowed            │
│ Links       │ https://platform.zapier.com/cli_docs/schema#authenticationschema@15.0.1 │
└─────────────┴─────────────────────────────────────────────────────────────────────────┘
Your integration is structurally invalid. Address concerns and run this command again.
```

This command responds with a Link that may be helpful for debugging.
However, that page no longer exists, so builders won't be able to get the help they need without finding the page themselves. 
We can fix it on the CLI tooling, but because of versioning, only apps on the new version will get the fix, and old ones will still see the same error. **To alleviate this issue, we can add an invisible page that users won't see on the site, but the URL is still active. This URL will automatically redirect the user to the correct Github schema docs page **

[Demo video](https://cdn.zappy.app/137d9a805d45553e0b3d1f4b203091cd.mp4)

