### PR TITLE
Update cli-docs.md to reflect how to handle reaching the end of a result set for cursor pagination

### DIFF
--- a/docs/_reference/cli-docs.md
+++ b/docs/_reference/cli-docs.md
@@ -3466,8 +3466,8 @@ const perform = async (z, bundle) => {
   );
 
   // after fetching a page, set the returned cursor for the next page,
-  // or empty/null if this was the last one.
-  await z.cursor.set(response.nextPage);
+  // or an empty string if this was the last one.
+  await z.cursor.set(response.nextPage ?? '');
 
   return response.items;
 };

--- a/docs/_reference/cli-docs.md
+++ b/docs/_reference/cli-docs.md
@@ -3466,7 +3466,7 @@ const perform = async (z, bundle) => {
   );
 
   // after fetching a page, set the returned cursor for the next page,
-  // or an empty string if this was the last one.
+  // or an empty string if the cursor is null
   await z.cursor.set(response.nextPage ?? '');
 
   return response.items;


### PR DESCRIPTION
Previous docs would throw an error if `response.nextPage` was `null` which is often the case, this change ensures an empty string gets set in the cursor which allows the other code to work as expected.