### PR TITLE
Sync CLI docs for version 15.4.1

### DIFF
--- a/docs/_reference/cli-docs.md
+++ b/docs/_reference/cli-docs.md
@@ -21,7 +21,7 @@ You may find some documents on the Zapier site duplicate or outdated. The most u
 
 Our code is updated frequently. To see a full list of changes, look no further than [the CHANGELOG](https://github.com/zapier/zapier-platform/blob/main/CHANGELOG.md).
 
-This doc describes the latest CLI version (**15.1.0**), as of this writing. If you're using an older version of the CLI, you may want to check out these historical releases:
+This doc describes the latest CLI version (**15.4.1**), as of this writing. If you're using an older version of the CLI, you may want to check out these historical releases:
 
 - CLI Docs: [14.x](https://github.com/zapier/zapier-platform/blob/zapier-platform-cli@14.1.2/packages/cli/README.md), [13.x](https://github.com/zapier/zapier-platform/blob/zapier-platform-cli@13.0.0/packages/cli/README.md)
 - CLI Reference: [14.x](https://github.com/zapier/zapier-platform/blob/zapier-platform-cli@14.1.2/packages/cli/docs/cli.md), [13.x](https://github.com/zapier/zapier-platform/blob/zapier-platform-cli@13.0.0/packages/cli/docs/cli.md)
@@ -94,6 +94,7 @@ This doc describes the latest CLI version (**15.1.0**), as of this writing. If y
 - [Environment](#environment)
   * [Defining Environment Variables](#defining-environment-variables)
   * [Accessing Environment Variables](#accessing-environment-variables)
+- [Adding Throttle Configuration](#adding-throttle-configuration)
 - [Making HTTP Requests](#making-http-requests)
   * [Shorthand HTTP Requests](#shorthand-http-requests)
   * [Manual HTTP Requests](#manual-http-requests)
@@ -2153,6 +2154,62 @@ const App = {
 > Note! Be sure to lazily access your environment variables - see [When to use placeholders or curlies?](#when-to-use-placeholders-or-curlies).
 
 
+## Adding Throttle Configuration
+
+*Added in v15.4.0.*
+
+When a throttle configuration is set for an action, Zapier uses it to apply throttling when the limit for the timeframe window is exceeded. It can be set at the root level and/or on an action. When set at the root level, it is the default throttle configuration used on each action of the integration. And when set in an action's operation object, the root-level default is overwritten for that action only.
+
+To throttle an action, you need to set a `throttle` object with the following variables:
+  1. `window [integer]`: The timeframe, in seconds, within which the system tracks the number of invocations for an action. The number of invocations begins at zero at the start of each window.
+  2. `limit [integer]`: The maximum number of invocations for an action, allowed within the timeframe window.
+  3. `scope [array]`: The granularity to throttle by. You can set the scope to one or more of the following options;
+        - 'user' - Throttles based on user ids.
+        - 'auth' - Throttles based on auth ids.
+        - 'account' - Throttles based on account ids for all users under a single account.
+
+Except for the scope, all throttle variables are required. By default, throttling is scoped to the account.
+
+Here is a typical usage of the throttle configuration:
+
+```js
+const App = {
+  version: require('./package.json').version,
+  platformVersion: require('zapier-platform-core').version,
+
+  // default throttle used for each action
+  throttle: {
+    window: 600,
+    limit: 50,
+    scope: ['account'],
+  },
+
+  creates: {
+    upload_video: {
+      noun: 'Video',
+      display: {
+        label: 'Upload Video',
+        description: 'Upload a video.',
+      },
+      operation: {
+        perform: () => {},
+        inputFields: [],
+        // overwrites the default, for this action
+        throttle: {
+          window: 600,
+          limit: 5,
+          scope: ['account'],
+        },
+      },
+    },
+  },
+};
+
+module.exports = App;
+
+```
+
+
 ## Making HTTP Requests
 
 There are two ways to make HTTP requests:
@@ -2407,7 +2464,7 @@ This behavior has changed periodically across major versions, which changes how/
 
 ![](https://cdn.zappy.app/e835d9beca1b6489a065d51a381613f3.png)
 
-Ensure you're handling errors correctly for your platform version. The latest released version is **15.1.0**.
+Ensure you're handling errors correctly for your platform version. The latest released version is **15.4.1**.
 
 ### HTTP Request Options
 
@@ -3578,7 +3635,7 @@ Broadly speaking, all releases will continue to work indefinitely. While you nev
 For more info about which Node versions are supported, see [the faq](#how-do-i-manually-set-the-nodejs-version-to-run-my-app-with).
 
 <!-- TODO: if we decouple releases, change this -->
-The most recently released version of `cli` and `core` is **15.1.0**. You can see the versions you're working with by running `zapier -v`.
+The most recently released version of `cli` and `core` is **15.4.1**. You can see the versions you're working with by running `zapier -v`.
 
 To update `cli`, run `npm install -g zapier-platform-cli`.
 


### PR DESCRIPTION
Sync CLI docs for the use of throttle configuration - https://github.com/zapier/zapier-platform/blob/main/packages/cli/README.md#adding-throttle-configuration