### PR TITLE
[SUPPORTENG-983] Add #team-platform-support as codeowners to Docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 *                   @zapier/epd-dev-platform-content
 /docs/_embed/       @zapier/epd-partner-sharing
 /docs/_partners/    @zapier/epd-partner-sharing
-/docs   @zapier/team-platform-support
+/docs               @zapier/team-platform-support

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,4 @@
 *                   @zapier/epd-dev-platform-content
 /docs/_embed/       @zapier/epd-partner-sharing
 /docs/_partners/    @zapier/epd-partner-sharing
-
 /docs   @zapier/team-platform-support

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,5 @@
 *                   @zapier/epd-dev-platform-content
 /docs/_embed/       @zapier/epd-partner-sharing
 /docs/_partners/    @zapier/epd-partner-sharing
+
+/docs   @zapier/team-platform-support


### PR DESCRIPTION
Platform Support is in the process of overhauling the developer docs. And would like to be added as Codeowners and approvers of any future changes to the Visual Builder docs. 