### PR TITLE
[PDE-4499] Add details about hook subscription auto-refresh to docs

### DIFF
--- a/docs/_build/triggers/cli-hook-trigger.md
+++ b/docs/_build/triggers/cli-hook-trigger.md
@@ -25,6 +25,7 @@ Zapier does not support Identity Confirmation for webhook subscriptions.
 - A way to store the unique URLs we send you, such as a database.
 - A way to send payloads in JSON format to each stored URL, when a specific event happens that you want to trigger the associated Zap on.
 - One or more endpoint(s) to receive subscribe and unsubscribe payloads (these can be the same endpoint(s) or separate ones)
+- If your webhook subscriptions expire, make sure the subscribe endpoint returns an `expiration_date` property containing an ISO8601 date. The platform will automatically attempt to resubscribe after the expiration date.
 
 When a Zap is turned on, the `subscribeHook` function is called with a payload of data that includes the unique URL to send data to in order to trigger the Zap. Store this URL, associating it with an id and use it whenever you want to trigger this Zap. Return that id in the response back to Zapier to be used later in the Unsubscribe.
 

--- a/docs/_build/triggers/hook-trigger.md
+++ b/docs/_build/triggers/hook-trigger.md
@@ -15,6 +15,7 @@ Set up your REST Hook trigger in the Platform UI with the Settings, Input Design
 - Your app supports REST Hooks - webhook subscriptions that can be manipulated through a REST API.
 - An endpoint/s to set up and remove the hook subscription exists for Zapier to send Subscribe and Unsubscribe API requests to with a unique subscription URL, the`bundle.targetUrl`, for each active Zap.
 - A separate endpoint exists that returns a list of sample items that would be expected to trigger the user's Zap. This is optional for apps remaining private and ***required*** for public apps.
+- If your webhook subscriptions expire, make sure the subscribe endpoint returns an `expiration_date` property containing an ISO8601 date. The platform will automatically attempt to resubscribe after the expiration date.
 
 ## 1. Add the trigger settings
 


### PR DESCRIPTION
A ticket was created here: https://zapierorg.atlassian.net/browse/UDOCS-1631 to document this, but that was never taken care of, and this has come up several times since then.

This PR explicitly documents this feature per the discussion/request in [PDE-4499](https://zapierorg.atlassian.net/browse/PDE-4499).