### PR TITLE
[PARTOPS-861] Remove redirect to renamed "Must have trigger and actions" doc

### DIFF
--- a/docs/_quickstart/must-have-triggers-and-actions.md
+++ b/docs/_quickstart/must-have-triggers-and-actions.md
@@ -20,7 +20,7 @@ table {
   }
 </style>
 
-# Integration design examples
+# Must have triggers and actions
 
 Whether you're just starting to scope out a new Zapier integration build or have successfully launched your app in the Zapier App Directory, it's helpful to know what features users find the most valuable and are the most widely used across Zapier's various [app categories](https://zapier.com/apps). Ensuring your integration covers the foundational triggers, actions, and searches applicable to your app will provide more utility to your users.
 

--- a/docs/_quickstart/must-have-triggers-and-actions.md
+++ b/docs/_quickstart/must-have-triggers-and-actions.md
@@ -1,5 +1,5 @@
 ---
-title: Must have triggers and actions
+title: Must-have triggers and actions
 order: 1
 layout: post-toc
 redirect_from:
@@ -20,7 +20,7 @@ table {
   }
 </style>
 
-# Must have triggers and actions
+# Must-have triggers and actions
 
 Whether you're just starting to scope out a new Zapier integration build or have successfully launched your app in the Zapier App Directory, it's helpful to know what features users find the most valuable and are the most widely used across Zapier's various [app categories](https://zapier.com/apps). Ensuring your integration covers the foundational triggers, actions, and searches applicable to your app will provide more utility to your users.
 

--- a/docs/_reference/use-cases/forms-app.md
+++ b/docs/_reference/use-cases/forms-app.md
@@ -4,7 +4,6 @@ order: 1
 layout: post-toc
 redirect_from: 
     - /partners/integration-examples
-    - /quickstart/integration-design-examples
 ---
 
 # Zapier integration structure for a forms app


### PR DESCRIPTION
Currently, URLs to /quickstart/integration-design-examples redirect to the forms reference,