### PR TITLE
PDE-4540 - Fix previous and next navigation links

### DIFF
--- a/_includes/javascript.html
+++ b/_includes/javascript.html
@@ -121,3 +121,36 @@ menuToggle.addEventListener('click', function(event) {
   document.addEventListener("keydown", keyDownHandler);
 })();
 </script>
+
+
+<script>
+  document.addEventListener('DOMContentLoaded', function() {
+    const sidebarLinks = document.querySelectorAll('.sidebar__list-link');
+    const currentUrl = window.location.pathname;
+    let currentIndex = -1;
+
+    const linksArray = Array.from(sidebarLinks);
+
+    linksArray.forEach((link, index) => {
+        if (link.getAttribute('href') === currentUrl) {
+            currentIndex = index;
+        }
+    });
+
+    if (currentIndex !== -1) {
+        const prevLink = linksArray[currentIndex - 1];
+        const nextLink = linksArray[currentIndex + 1];
+
+        if (prevLink) {
+            document.getElementById('previous_page').href = prevLink.href;
+            document.getElementById('previous_page').textContent = prevLink.textContent.trim();
+        }
+
+        if (nextLink) {
+            document.getElementById('next_page').href = nextLink.href;
+            document.getElementById('next_page').textContent = nextLink.textContent.trim();
+        }
+    }
+});
+
+</script>

--- a/_includes/javascript.html
+++ b/_includes/javascript.html
@@ -142,13 +142,20 @@ menuToggle.addEventListener('click', function(event) {
         const nextLink = linksArray[currentIndex + 1];
 
         if (prevLink) {
+            document.getElementById('previous_page').style.visibility = "visible"
             document.getElementById('previous_page').href = prevLink.href;
-            document.getElementById('previous_page').textContent = prevLink.textContent.trim();
+            document.getElementById('previous_page').textContent = "Previous: " + prevLink.textContent.trim();
+        } else {
+            document.getElementById('previous_page').style.visibility = "hidden"
         }
 
         if (nextLink) {
+            document.getElementById('next_page').style.visibility = "visible"
             document.getElementById('next_page').href = nextLink.href;
-            document.getElementById('next_page').textContent = nextLink.textContent.trim();
+            document.getElementById('next_page').textContent = "Next: " + nextLink.textContent.trim();
+        } else {
+          document.getElementById('next_page').style.visibility = "hidden"
+
         }
     }
 });

--- a/_includes/prev-next.html
+++ b/_includes/prev-next.html
@@ -15,5 +15,5 @@
 {% endfor %}
 
 <hr>
-{% if prev %}<a class="button blue" href="{{ site.baseurl }}{{ prev.url}}">Previous: {{ prev.title }}</a>{% endif %}
-{% if next %}<a class="button blue" href="{{ site.baseurl }}{{ next.url}}">Next: {{ next.title }}</a>{% endif %}
+{% if prev %}<a id="previous_page" class="button blue" href="{{ site.baseurl }}{{ prev.url}}">Previous: {{ prev.title }}</a>{% endif %}
+{% if next %}<a id="next_page" class="button blue" href="{{ site.baseurl }}{{ next.url}}">Next: {{ next.title }}</a>{% endif %}


### PR DESCRIPTION
Nav for previous and next page were broken.
This fix uses JS which will find the ordered list of links. After finding the link that matches the current page, it will find the previous and next link by decrementing and incrementing the current index by one. 

We can then inject the two buttons and change the href and text with the corresponding link and texts. 


# Before
![](https://cdn.zappy.app/930cae4cc0083aa9cfecf644f34bd375.png) 

# After 
![](https://cdn.zappy.app/79ee71d83f504d579cbad08c23bef956.png)
