### PR TITLE
TPS-3012 Adds the trailing slash to https://zapier.com/oauth/authorize/ documentation

### DIFF
--- a/docs/_embed/solutions/partner-api.md
+++ b/docs/_embed/solutions/partner-api.md
@@ -257,7 +257,7 @@ For resources that require a valid access token you can use the [OAuth2 protocol
 Construct the following URL, and redirect the user to authorize your application:
 
 ```
-https://zapier.com/oauth/authorize?client_id={client_id}&redirect_uri={redirect_uri}&scope={scope}
+https://zapier.com/oauth/authorize/?client_id={client_id}&redirect_uri={redirect_uri}&scope={scope}
 ```
 
 |      Parameter      | Requirement | Explanation                                                                                                                                                                                                         |


### PR DESCRIPTION
This MR adds the correct trailing slash to https://zapier.com/oauth/authorize/.

Technically, `/authorize` redirects to `/authorize/`, so this isn't strictly necessary here, but as we move to authorization code flow, `/token/` must be used rather than `/token` (no redirect occurs), so we should stay consistent to avoid confusion.

See other updates: https://gitlab.com/zapier/public-api/public-api/-/merge_requests/134