### PR TITLE
[PARTOPS-1027] Add links to partner embed gallery

### DIFF
--- a/docs/_embed/embed-benefits.md
+++ b/docs/_embed/embed-benefits.md
@@ -23,6 +23,9 @@ Users can extend the power of your app when Zapier looks like an extension of yo
 
 To help your integration become more visible, try one or all of these options to begin connecting your users with Zapier’s {{site.partner_count}} integrations.
 
+### Explore examples of live embeds
+Head over to the [Partner Embed Gallery](https://zapier.com/developer-platform/partner-embeds) to see how other Partners have successfully utilized the various embed tools to showcase their integration, gain more users, and simplify how their users connect their app with thousands of other tools.
+
 ### Enable users to connect to Zapier faster through accelerated sign-ups
 **Why?** The [Quick Account Creation](https://platform.zapier.com/embed/quick-account-creation) feature allows you to make it easy for your users to sign up for a Zapier account while using your embed tool.
 **How?** Seamless user signups = more usage of your integration. Check how [Zapier Partner Adalo started using this feature](https://zapier.com/blog/adalo-user-experience-with-zapier/) and saw a 40 percent increase in users successfully creating Zaps. And it took less than a day to get set up!

--- a/docs/_embed/quick-account-creation.md
+++ b/docs/_embed/quick-account-creation.md
@@ -20,6 +20,8 @@ This video demonstrates how to implement Quick Account Creation using the Zap te
 
 <iframe allowtransparency="true" title="Search or create" allowFullscreen frameborder="0" scrolling="no" class="wistia_embed" name="wistia_embed" src="https://cdn.zappy.app/v1f21dbddbc570407248253c13859a5d9.mp4" width="640" height="360"></iframe>
 
+Explore more live examples and success stories in our [Partner Embed Gallery](https://zapier.com/developer-platform/partner-embeds).
+
 ## Prerequisites
 
 - New or existing implementation of the [Full Zapier Experience](https://platform.zapier.com/embed/full-zapier-experience), [Zap templates element](https://platform.zapier.com/embed/zap-templates), or [Partner API](https://platform.zapier.com/embed/partner-api).

--- a/docs/_embed/solutions/full-zapier-experience.md
+++ b/docs/_embed/solutions/full-zapier-experience.md
@@ -24,6 +24,8 @@ This video shows an example implementation of the Full Zapier Experience, and ho
 
 <iframe allowtransparency="true" title="Wistia video player" allowFullscreen frameborder="0" scrolling="no" class="wistia_embed" name="wistia_embed" src="https://fast.wistia.net/embed/iframe/84kpi5zau6" width="640" height="360"></iframe>
 
+Explore more live examples and success stories in our [Partner Embed Gallery](https://zapier.com/developer-platform/partner-embeds).
+
 ## Customize
 
 The [generator](https://zapier.com/partner/solutions/plug-and-play) lets you customize the visual design and features of Zapier you want to include, and generate code snippets that can be copied and pasted directly into your site. Generate the embed code in HTML, Vanilla JS, React, Angular, or Vue.js 2. No engineering resources are required.

--- a/docs/_embed/solutions/partner-api.md
+++ b/docs/_embed/solutions/partner-api.md
@@ -52,6 +52,8 @@ Unbounce uses the `/zaps` endpoint to display users' Zaps using their integratio
 
 <iframe allowtransparency="true" title="Wistia video player" allowFullscreen frameborder="0" scrolling="no" class="wistia_embed" name="wistia_embed" src="https://fast.wistia.net/embed/iframe/zhls72cz15" width="640" height="360"></iframe>
 
+Explore more live examples and success stories in our [Partner Embed Gallery](https://zapier.com/developer-platform/partner-embeds).
+
 ## Embed Zap editor with Partner API
 
 With an embedded Zap editor in your product, your users can create and edit their Zaps without leaving your app.

--- a/docs/_embed/solutions/zap-templates.md
+++ b/docs/_embed/solutions/zap-templates.md
@@ -32,3 +32,5 @@ Find the Zap Templates generator under Embed on the left-hand menu of your integ
 This video shows an example implementation of the Zap Templates element embedded within the Zoho Sheet platform to surface popular workflows for users to easily discover and create Zaps:
 
 <iframe allowtransparency="true" title="Wistia video player" allowFullscreen frameborder="0" scrolling="no" class="wistia_embed" name="wistia_embed" src="https://fast.wistia.net/embed/iframe/hg0qtkr80v" width="640" height="360"></iframe>
+
+Explore more live examples and success stories in our [Partner Embed Gallery](https://zapier.com/developer-platform/partner-embeds).


### PR DESCRIPTION
Our new Partner embed gallery has launched! https://zapier.com/developer-platform/partner-embeds

Adding links to the gallery on the "Benefits" page of the Embed section, as well as links within each embed tool's respective page under the "Example implementation" sections.