### PR TITLE
PDE-4878 - Add missing 'to' in cli docs

### DIFF
--- a/docs/_reference/cli-docs.md
+++ b/docs/_reference/cli-docs.md
@@ -1237,7 +1237,7 @@ Notably, fields come in different types, which may look and act differently in t
 | `datetime` | Accepts both [precise and human-readable date-time values](https://help.zapier.com/hc/en-us/articles/8496259603341-Different-field-types-in-Zaps#date-time-fields-0-0). Passes along an ISO-formatted time string. |
 | `file` | Accepts a file object or a string. If a URL is provided in the string, Zapier will automatically make a GET for that file. Otherwise, a text file will be generated. |
 | `password` | Displays entered characters as hidden, accepts text input. Does not accept input from previous steps. |
-| `copy` | Does not allow users enter data. Shows the value of the Markdown-formatted Help Text for the field as a rich text note in the Zap editor. Good for important notices to users. |
+| `copy` | Does not allow users to enter data. Shows the value of the Markdown-formatted Help Text for the field as a rich text note in the Zap editor. Good for important notices to users. |
 
 You can find more details on the different field schema options at [our Field Schema](https://github.com/zapier/zapier-platform/blob/main/packages/schema/docs/build/schema.md#fieldschema).
 


### PR DESCRIPTION
Tiny update for missing word in CLI docs.

Does not allow users enter data. -> Does not allow users **to** enter data.