### PR TITLE
[PARTOPS-1028] Add loki status info to User Feedback doc

### DIFF
--- a/docs/_manage/integration-performance/user-feedback.md
+++ b/docs/_manage/integration-performance/user-feedback.md
@@ -14,7 +14,7 @@ redirect_from:
 
 For public integrations, Zapier's Support team logs user requests and reported problems in Zapier's issue tracker, that your team can see from the _Bug & Feature Requests_ page in the Manage section. 
 
-![Issues in Zapier Integration](https://cdn.zappy.app/94abfa479ae98ff706e93e24999a125a.png)
+![Issues in Zapier Integration](https://cdn.zappy.app/b986eef73a1558ee3e121cf5d985339a.png)
 
 Problems with your public integration, authentication and API calls will be logged as `bug`, while new functionality users request for your app integration will be logged as `feature request`. You have the ability to filter open `bugs` and `feature requests` to view issues by individual Trigger or Action.
 
@@ -32,7 +32,7 @@ Problems with your public integration, authentication and API calls will be logg
 
 - Reply to the Zapier team about the issue within the _Bugs & Feature Requests_ page to keep communications consistent for both your team and ours. These issues and comments are not visible to affected users; and users will only be notified when an issue is verified as closed/resolved by Zapier Support.
 
-![Reply to Zapier Integration Issue](https://cdn.zappy.app/a5808bdc70214728d0eac9f569f2d2e7.png)
+![Reply to Zapier Integration Issue](https://cdn.zappy.app/2f7af76046895c4b4f053a1b1ce9781d.png)
 
 - Lowering your count of issues will help improve your integration’s [health score](https://platform.zapier.com/publish/partner-program#integration-health-score) and increase your tier in the [Partner Program](https://zapier.com/platform/partner-program). The more you maintain a bug-free, quality integration, the more essential your product becomes to your users' workflows. This sets you up to reduce churn, drive account upgrades, and increase customer lifetime value.
 
@@ -106,6 +106,9 @@ Any reported issue with no updates from you, Zapier Support, or end users for a 
 Maintaining accurate issue statuses during regular triage and review of your integration's issues is critical for keeping your integration healthy. Not only do statuses help your team track progress and build roadmaps, but they also signal your engagement and prompt reviews for fixed issues to the Zapier team.
 
 <iframe style="border: 1px solid rgba(0, 0, 0, 0.1);" width="600" height="500" src="https://on.driveway.app/guides/zEVVdGE/embed" allow="clipboard-write" allowfullscreen></iframe>
+<p style="font-family: Helvetica, sans-serif; font-size: 12px; color: gray;">
+    Click on "Enter Fullscreen" for a better demo experience.
+</p>
 
 Available statuses:
 

--- a/docs/_manage/integration-performance/user-feedback.md
+++ b/docs/_manage/integration-performance/user-feedback.md
@@ -14,7 +14,7 @@ redirect_from:
 
 For public integrations, Zapier's Support team logs user requests and reported problems in Zapier's issue tracker, that your team can see from the _Bug & Feature Requests_ page in the Manage section. 
 
-![Issues in Zapier Integration](https://cdn.zappy.app/b986eef73a1558ee3e121cf5d985339a.png)
+![Issues in Zapier Integration](https://cdn.zappy.app/94abfa479ae98ff706e93e24999a125a.png)
 
 Problems with your public integration, authentication and API calls will be logged as `bug`, while new functionality users request for your app integration will be logged as `feature request`. You have the ability to filter open `bugs` and `feature requests` to view issues by individual Trigger or Action.
 
@@ -55,7 +55,7 @@ Any reported issue with no updates from you, Zapier Support, or end users for a 
 
 - You can also request issues to be closed manually by updating their statuses to `Done`. Make sure updates are promoted to the latest version of your integration, and users are migrated if possible before marking issues before marking issues as `Done`, as it will be reviewed by a Zapier support member. See the [`Utilizing issue statuses` section](https://platform.zapier.com/manage/user-feedback#utilizing-issue-statuses) below for more details and best practices.
 
-## 4. Consider Zapier Issue Manager
+## 4. Consider Zapier Issue Manager (ZIM)
 
 - If you prefer syncing and managing issues from your own issue-tracking tools (such as Jira or Trello), create Zaps using Zapier Issue Manager.
 

--- a/docs/_manage/integration-performance/user-feedback.md
+++ b/docs/_manage/integration-performance/user-feedback.md
@@ -40,6 +40,8 @@ Problems with your public integration, authentication and API calls will be logg
 
 - Allocate ongoing resources in your team’s product roadmap for the maintenance of your Zapier integration to avoid surprise work or gaps in functionality. Consider a [Zapier Expert](https://zapier.com/experts/matchmaking) to help you fix one-off bugs or maintain your integration.
 
+- Keep issue statuses up-to-date as you regularly review, triage, and address your integration's issues. See the [`Utilizing issue statuses` section](https://platform.zapier.com/manage/user-feedback#utilizing-issue-statuses) below for more details and best practices.
+
 ### Dormant Issues
 Any reported issue with no updates from you, Zapier Support, or end users for a year will now be automatically closed. This keeps your workspace current and focused, making it simpler to stay on top of active issues.
 
@@ -51,9 +53,7 @@ Any reported issue with no updates from you, Zapier Support, or end users for a 
 
 ![Changelog Form with Issues](https://cdn.zappy.app/8afba17ecfb25faf6b87597e2cd54387.png)
 
-- You can also request issues to be closed manually by selecting one in the "Bugs & Feature Requests" tab of the developer platform, and leaving a comment to our Support team that the issue has been resolved. Provide info on what version number the fix is on, how to test the updates, and any other helpful callouts.
-
-- Once an issue is reviewed, it will either be closed or responded to with follow-up questions and feedback.
+- You can also request issues to be closed manually by updating their statuses to `Done`. Make sure updates are deployed and promoted to the lastest version of your integration before marking issues as `Done`, as it will be reviewed by a Zapier support member. See the [`Utilizing issue statuses` section](https://platform.zapier.com/manage/user-feedback#utilizing-issue-statuses) below for more details and best practices.
 
 ## 4. Consider Zapier Issue Manager
 
@@ -100,3 +100,25 @@ Any reported issue with no updates from you, Zapier Support, or end users for a 
 - Usage details for each trigger and action will show which functionalities are the most popular and being effectively utilized. 
 
 - Share access to the insights by [inviting collaborators](https://platform.zapier.com/manage/invite-team-member) to the integration without giving them permissions to make changes to it.
+
+## Utilizing issue statuses
+
+Maintaining accurate issue statuses during regular triage and review of your integration's issues is critical for keeping your integration healthy. Not only do statuses help your team track progress and build roadmaps, but they also signal your engagement and prompt reviews for fixed issues to the Zapier team.
+
+Available statuses:
+
+* _Open_: The issue is open and no action has been taken.
+* _Planned_: Work has been committed to address the issue, but has not started.
+* _In Progress_: This issue is being actively worked on.
+* _Done_: Work is completed, and the updates for the issue have been promoted.
+* _Under review_: Zapier is reviewing the work completed on the issue.
+* _Rejected_: After review, Zapier deemed the issue resolution not complete.
+
+Once an issue is resolved, update the issue status to `Done`. You will be prompted to select one of the following issue resolutions:
+
+* _Resolved_: Work is completed and updates have been promoted.
+* _Won’t Do_: This issue won't be actioned (i.e. not on the roadmap, not technically possible, etc.). A comment explaining why is required.
+* _Duplicate_: The issue is a duplicate of another issue. Please note the duplicate issue in the required comment.
+* _Cannot Reproduce_: All attempts at reproducing this issue failed.
+
+All issues marked `Done` are reviewed by the Zapier team for accuracy and completion. Any necessary explanation or feedback will be provided via comments on respective the issues after the internal review.

--- a/docs/_manage/integration-performance/user-feedback.md
+++ b/docs/_manage/integration-performance/user-feedback.md
@@ -105,6 +105,8 @@ Any reported issue with no updates from you, Zapier Support, or end users for a 
 
 Maintaining accurate issue statuses during regular triage and review of your integration's issues is critical for keeping your integration healthy. Not only do statuses help your team track progress and build roadmaps, but they also signal your engagement and prompt reviews for fixed issues to the Zapier team.
 
+<iframe style="border: 1px solid rgba(0, 0, 0, 0.1);" width="600" height="500" src="https://on.driveway.app/guides/zEVVdGE/embed" allow="clipboard-write" allowfullscreen></iframe>
+
 Available statuses:
 
 * _Open_: The issue is open and no action has been taken.

--- a/docs/_manage/integration-performance/user-feedback.md
+++ b/docs/_manage/integration-performance/user-feedback.md
@@ -53,7 +53,7 @@ Any reported issue with no updates from you, Zapier Support, or end users for a 
 
 ![Changelog Form with Issues](https://cdn.zappy.app/8afba17ecfb25faf6b87597e2cd54387.png)
 
-- You can also request issues to be closed manually by updating their statuses to `Done`. Make sure updates are deployed and promoted to the lastest version of your integration before marking issues as `Done`, as it will be reviewed by a Zapier support member. See the [`Utilizing issue statuses` section](https://platform.zapier.com/manage/user-feedback#utilizing-issue-statuses) below for more details and best practices.
+- You can also request issues to be closed manually by updating their statuses to `Done`. Make sure updates are promoted to the latest version of your integration, and users are migrated if possible before marking issues before marking issues as `Done`, as it will be reviewed by a Zapier support member. See the [`Utilizing issue statuses` section](https://platform.zapier.com/manage/user-feedback#utilizing-issue-statuses) below for more details and best practices.
 
 ## 4. Consider Zapier Issue Manager
 
@@ -121,4 +121,4 @@ Once an issue is resolved, update the issue status to `Done`. You will be prompt
 * _Duplicate_: The issue is a duplicate of another issue. Please note the duplicate issue in the required comment.
 * _Cannot Reproduce_: All attempts at reproducing this issue failed.
 
-All issues marked `Done` are reviewed by the Zapier team for accuracy and completion. Any necessary explanation or feedback will be provided via comments on respective the issues after the internal review.
+All issues marked `Done` are reviewed by the Zapier team for accuracy and completion. Any necessary explanation or feedback will be provided via comments on respective issues after the internal review. Please respond with questions or concerns on the appropriate issue to keep discussions clear.


### PR DESCRIPTION
[Loki Status project brief](https://coda.io/d/Team-Developer-Platform_di0MgBhlCWf/One-Pager-Loki-Issue-Statuses_su4o4#_lutLR)

Adding information about the new loki statues on the existing "Respond to user feedback and bugs" platform doc.