### PR TITLE
[PLATSUP-1036] Switch quickstart collection redirect to match sidebar

### DIFF
--- a/docs/_manage/account-and-team/add-team.md
+++ b/docs/_manage/account-and-team/add-team.md
@@ -3,7 +3,6 @@ title: Add team members to integration
 order: 1
 layout: post-toc
 redirect_from: 
-    - /quickstart/
     - /quickstart/invite-team-member
     - /manage/invite-team-member
 ---

--- a/docs/_quickstart/build-private-integration.md
+++ b/docs/_quickstart/build-private-integration.md
@@ -2,7 +2,9 @@
 title: Build your first private integration
 order: 1
 layout: post-toc
-redirect_from: /private_integrations/build-a-private-integration
+redirect_from: 
+    - /quickstart/
+    - /private_integrations/build-a-private-integration
 ---
 
 # Build your first private integration on Zapier


### PR DESCRIPTION
This is a small test [before I push additional redirect changes](https://zapierorg.atlassian.net/browse/PLATSUP-1036). 

Context:

When running locally, Jekyll adds `/search/` to the path on the Search page, so redirects like `/quickstart/` alone do not work—at least, not without adding additional `/search/...` redirects.

![Screen Shot 2024-04-19 at 11 24 08 AM](https://github.com/zapier/visual-builder/assets/57920178/7c43ea62-6ade-4c51-a3df-7357e278f01a)

However, we don't see `/search/` in the path in production, so this PR is intended to test if the redirect behaves as expected. If all goes as expected, I'll update the redirects for the other collections.

Acceptance criteria:

1. The Quickstart link in the sidebar continues to point to "Build your first private integration on Zapier"
2. The Quickstart collection link in search results also points to "Build your first private integration on Zapier" (currently goes to Manage > Invite Team Members...)

![image](https://github.com/zapier/visual-builder/assets/57920178/ba3754c9-6db5-4182-8859-8fe6fb1ab486)

