### PR TITLE
Update Build, Manage, Publish, and Reference collection redirects [PLATSUP-1036]

### DIFF
--- a/docs/_build/actions/action.md
+++ b/docs/_build/actions/action.md
@@ -5,7 +5,7 @@ layout: post-toc
 redirect_from: 
     - /quickstart/build-action
     - /docs/actions
-
+    - /build/
 ---
 
 # Action

--- a/docs/_manage/account-and-team/add-team.md
+++ b/docs/_manage/account-and-team/add-team.md
@@ -5,6 +5,7 @@ layout: post-toc
 redirect_from: 
     - /quickstart/invite-team-member
     - /manage/invite-team-member
+    - /manage/
 ---
 
 # Invite team members to your integration

--- a/docs/_publish/branding/branding-guidelines.md
+++ b/docs/_publish/branding/branding-guidelines.md
@@ -5,6 +5,7 @@ layout: post-toc
 redirect_from: 
   - /partners/planning-guide
   - /publish/integration-brand-design-guidelines
+  - /publish/
 ---
 
 # Company branding guidelines

--- a/docs/_reference/cli-docs.md
+++ b/docs/_reference/cli-docs.md
@@ -2,7 +2,9 @@
 title: Zapier Platform CLI docs
 order: 1
 layout: post-toc
-redirect_from: /cli_docs/docs
+redirect_from: 
+    - /cli_docs/docs
+    - /reference/
 ---
 
 {% raw %}


### PR DESCRIPTION
https://zapierorg.atlassian.net/browse/PLATSUP-1036 

The [previous PR](https://github.com/zapier/visual-builder/pull/611), intended as a test, worked as expected:

- The Quickstart link in the sidebar remained unchanged
- The Quickstart link in search results now points to the correct article

This PR adds additional redirections for these collections:

- Build
- Manage
- Publish
- Reference

Two quick notes:

First, if you test this PR locally, it will likely not work. For some reason, Jekyll adds `/search/` to collection link paths locally but not in prod.

Second, I've chosen not to update Embed. The sidebar link points to "Benefits" while the search results link points to the "Full Zapier Experience." I suspect there are places intentionally linking to `/embed/` as a path to info on the Full Zapier Experience.