### PR TITLE
[PARTOPS-1066] Remove hyperlink from header which was confusing and add it to the body content

### DIFF
--- a/docs/_embed/partner-solutions.md
+++ b/docs/_embed/partner-solutions.md
@@ -38,7 +38,7 @@ redirect_from:
 
 # Partner Solutions Documentation
 
-Our partner solutions are the easiest ways to embed Zapier and surface integrations within your product. Check out the [Partner Solutions documentation](https://docs.api.zapier.com/guides/intro) to learn about [plug-and-play elements](https://docs.api.zapier.com/guides/workflow-element/zap-templates-element  ), the [Workflow API](https://docs.api.zapier.com/api-reference/getting-started/authentication), [quick account creation](https://docs.api.zapier.com/guides/quac/intro-quac), and more.
+Our partner solutions are the easiest ways to embed Zapier and surface integrations within your product. Check out the [Partner Solutions documentation](https://docs.api.zapier.com/guides/intro) to learn about [plug-and-play elements](https://docs.api.zapier.com/guides/workflow-element/zap-templates-element), the [Workflow API](https://docs.api.zapier.com/api-reference/getting-started/authentication), [quick account creation](https://docs.api.zapier.com/guides/quac/intro-quac), and more.
 
 Zapier’s partner solutions are available for public integrations. To take advantage of our embed solution, first ensure your integration has been published to [Zapier’s App Directory](https://zapier.com/apps). If your integration isn’t yet published, learn more about [submitting your integration for review](https://platform.zapier.com/publish/public-integration#4-submit-your-integration-for-app-review).
 

--- a/docs/_embed/partner-solutions.md
+++ b/docs/_embed/partner-solutions.md
@@ -38,7 +38,7 @@ redirect_from:
 
 # Partner Solutions Documentation
 
-Our [Embed docs](https://docs.api.zapier.com/guides/intro) have moved.
+Heads up, our [Embed docs](https://docs.api.zapier.com/guides/intro) have moved.
 
 Our partner solutions are the easiest ways to embed Zapier and surface integrations within your product. Check out the [Partner Solutions documentation](https://docs.api.zapier.com/guides/intro) to learn about [plug-and-play elements](https://docs.api.zapier.com/guides/workflow-element/zap-templates-element), the [Workflow API](https://docs.api.zapier.com/api-reference/getting-started/authentication), [quick account creation](https://docs.api.zapier.com/guides/quac/intro-quac), and more.
 

--- a/docs/_embed/partner-solutions.md
+++ b/docs/_embed/partner-solutions.md
@@ -38,6 +38,8 @@ redirect_from:
 
 # Partner Solutions Documentation
 
+Our [Embed docs](https://docs.api.zapier.com/guides/intro) have moved.
+
 Our partner solutions are the easiest ways to embed Zapier and surface integrations within your product. Check out the [Partner Solutions documentation](https://docs.api.zapier.com/guides/intro) to learn about [plug-and-play elements](https://docs.api.zapier.com/guides/workflow-element/zap-templates-element), the [Workflow API](https://docs.api.zapier.com/api-reference/getting-started/authentication), [quick account creation](https://docs.api.zapier.com/guides/quac/intro-quac), and more.
 
 Zapier’s partner solutions are available for public integrations. To take advantage of our embed solution, first ensure your integration has been published to [Zapier’s App Directory](https://zapier.com/apps). If your integration isn’t yet published, learn more about [submitting your integration for review](https://platform.zapier.com/publish/public-integration#4-submit-your-integration-for-app-review).

--- a/docs/_embed/partner-solutions.md
+++ b/docs/_embed/partner-solutions.md
@@ -36,9 +36,9 @@ redirect_from:
 
 ---
 
-# [Partner Solutions Documentation](https://docs.api.zapier.com/guides/intro)
+# Partner Solutions Documentation
 
-Our partner solutions are the easiest ways to surface integrations within your product. 
+Our partner solutions are the easiest ways to embed Zapier and surface integrations within your product. Check out the [Partner Solutions documentation](https://docs.api.zapier.com/guides/intro) to learn about [plug-and-play elements](https://docs.api.zapier.com/guides/workflow-element/zap-templates-element  ), the [Workflow API](https://docs.api.zapier.com/api-reference/getting-started/authentication), [quick account creation](https://docs.api.zapier.com/guides/quac/intro-quac), and more.
 
 Zapier’s partner solutions are available for public integrations. To take advantage of our embed solution, first ensure your integration has been published to [Zapier’s App Directory](https://zapier.com/apps). If your integration isn’t yet published, learn more about [submitting your integration for review](https://platform.zapier.com/publish/public-integration#4-submit-your-integration-for-app-review).
 


### PR DESCRIPTION
Partner and myself were confused with how to get to the new docs since it was the header that was linked. Removed header hyperlink and added links directly to the body content.