### PR TITLE
[PARTOPS-1066] Move Embed insights doc under Manage

### DIFF
--- a/docs/_manage/integration-performance/embed-insights.md
+++ b/docs/_manage/integration-performance/embed-insights.md
@@ -6,6 +6,7 @@ redirect_from:
     - /manage/analyze-integration-performance#embed-insights-definitions
     - /manage/analyze-integration-performance#practical-applications-of-embed-insights
     - https://platform.zapier.com/manage/embed-insights 
+    - https://platform.zapier.com/embed/embed-insights
 ---
 
 # Embed insights definitions 


### PR DESCRIPTION
Met with Product Marketing and Team Partner Sharing regarding transitioning embed docs from the original platform doc site to the new docs site (https://docs.api.zapier.com/guides/intro).

Michelle L. has added the embed insight definition content to the new doc site.

In order to move away focus on the "Embed" tab in the platform docs, this PR is to move existing embed insight definition doc under the "Manage > Integration Insights" section where all the other integration insight docs live.