### PR TITLE
[PARTOPS-1066] Remove redirect_from URL

### DIFF
--- a/docs/_manage/integration-performance/embed-insights.md
+++ b/docs/_manage/integration-performance/embed-insights.md
@@ -5,7 +5,7 @@ layout: post-toc
 redirect_from: 
     - /manage/analyze-integration-performance#embed-insights-definitions
     - /manage/analyze-integration-performance#practical-applications-of-embed-insights
-    - https://platform.zapier.com/embed/embed-insights
+    - /embed/embed-insights
 ---
 
 # Embed insights definitions 

--- a/docs/_manage/integration-performance/embed-insights.md
+++ b/docs/_manage/integration-performance/embed-insights.md
@@ -5,7 +5,6 @@ layout: post-toc
 redirect_from: 
     - /manage/analyze-integration-performance#embed-insights-definitions
     - /manage/analyze-integration-performance#practical-applications-of-embed-insights
-    - https://platform.zapier.com/manage/embed-insights 
     - https://platform.zapier.com/embed/embed-insights
 ---
 


### PR DESCRIPTION
Removing the redirect_from URL - https://platform.zapier.com/manage/embed-insights - as that's the new URL it's on, and updating full path redirect URL to partial path.