### PR TITLE
[PARTOPS-1104] Add zapier pull to cli reference

### DIFF
--- a/docs/_reference/cli.md
+++ b/docs/_reference/cli.md
@@ -433,7 +433,7 @@ Check `zapier jobs` to track the status of the promotion. Or use `zapier history
 
 ## pull
 
-> Retrieve and update your local integration filess with the latest version.
+> Retrieve and update your local integration files with the latest version.
 
 **Usage**: `zapier pull`
 

--- a/docs/_reference/cli.md
+++ b/docs/_reference/cli.md
@@ -431,6 +431,23 @@ Check `zapier jobs` to track the status of the promotion. Or use `zapier history
 * `zapier promote 1.0.0`
 
 
+## pull
+
+> Retrieve and update your local integration filess with the latest version.
+
+**Usage**: `zapier pull`
+
+This command updates your local integration files with the latest version. You will be prompted with a confirmation dialog before continuing if there any destructive file changes.
+
+Zapier may release new versions of your integration with bug fixes or new features. In the event this occurs, you will be unable to do the following until your local files are updated by running `zapier pull`:
+
+* push to the promoted version
+
+* promote a new version
+
+* migrate users from one version to another
+
+
 ## push
 
 > Build and upload the current integration.


### PR DESCRIPTION
Adding `zapier pull` command to CLI reference (info here: https://platform.zapier.com/manage/versions#managing-versions-in-platform-cli)